### PR TITLE
Clarify split licensing model in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,9 @@ Full documentation is available at **[autopilotmonitor.com/docs](https://www.aut
 
 ## License
 
-MIT License — see [LICENSE](LICENSE) for details
+This project uses a **split licensing model**:
+
+- **MIT License** — Agent (`src/Agent/`) and Shared library (`src/Shared/`) — unrestricted use on end-user devices
+- **AGPL-3.0** — Backend (`src/Backend/`), Web Dashboard (`src/Web/`), and MCP Server (`src/McpServer/`) — server-side components remain open source
+
+See [LICENSE](LICENSE) for full details.


### PR DESCRIPTION
The License section previously stated "MIT License" which was misleading,
as the project actually uses a split model (MIT for Agent/Shared, AGPL-3.0
for server-side components). Updated to reflect the actual licensing terms.

https://claude.ai/code/session_01WPv7ceMFvhU9GStDPcryRE