### PR TITLE
Add GitHub Actions workflow for building and releasing Agent

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -7,6 +7,11 @@ on:
         description: 'Build number override (leave empty to auto-increment from buildcounter.txt)'
         required: false
         type: string
+      upload_blob:
+        description: 'Upload ZIP + version.json to Azure Blob Storage'
+        required: true
+        type: boolean
+        default: true
       create_release:
         description: 'Create a GitHub Release'
         required: true
@@ -67,7 +72,9 @@ jobs:
           "tag=v$version" >> $env:GITHUB_OUTPUT
 
       - name: Restore dependencies
-        run: dotnet restore src/Agent/AutopilotMonitor.Agent/AutopilotMonitor.Agent.csproj
+        run: |
+          dotnet restore src/Agent/AutopilotMonitor.Agent/AutopilotMonitor.Agent.csproj
+          dotnet restore src/Agent/AutopilotMonitor.SummaryDialog/AutopilotMonitor.SummaryDialog.csproj
 
       - name: Build Agent
         run: >
@@ -76,6 +83,12 @@ jobs:
           --no-restore
         env:
           BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
+
+      - name: Build SummaryDialog
+        run: >
+          dotnet build src/Agent/AutopilotMonitor.SummaryDialog/AutopilotMonitor.SummaryDialog.csproj
+          --configuration Release
+          --no-restore
 
       - name: Update buildcounter.txt
         if: inputs.build_number == ''
@@ -90,33 +103,90 @@ jobs:
           git push
 
       - name: Create release artifact
+        id: artifact
         shell: pwsh
         run: |
           $version = "${{ steps.version.outputs.version }}"
-          $sourcePath = "src/Agent/AutopilotMonitor.Agent/bin/Release/net48"
-          $zipName = "AutopilotMonitor-Agent-v$version.zip"
+          $agentOutput = "src/Agent/AutopilotMonitor.Agent/bin/Release/net48"
+          $dialogOutput = "src/Agent/AutopilotMonitor.SummaryDialog/bin/Release/net48"
+          $stagingDir = "staging/agent"
 
-          # Verify build output exists
-          if (-not (Test-Path "$sourcePath/AutopilotMonitor.Agent.exe")) {
-            Write-Error "Agent build output not found at $sourcePath"
+          # Verify build outputs exist
+          if (-not (Test-Path "$agentOutput/AutopilotMonitor.Agent.exe")) {
+            Write-Error "Agent build output not found at $agentOutput"
+            exit 1
+          }
+          if (-not (Test-Path "$dialogOutput/AutopilotMonitor.SummaryDialog.exe")) {
+            Write-Error "SummaryDialog build output not found at $dialogOutput"
             exit 1
           }
 
-          # Create ZIP
-          Compress-Archive -Path "$sourcePath/*" -DestinationPath $zipName
-          Write-Host "Created artifact: $zipName"
+          # Create staging directory with Agent output as base
+          New-Item -Path $stagingDir -ItemType Directory -Force | Out-Null
+          Copy-Item -Path "$agentOutput/*" -Destination $stagingDir -Recurse -Force
+
+          # Copy SummaryDialog files into the same directory (Agent expects it next to itself)
+          Copy-Item -Path "$dialogOutput/AutopilotMonitor.SummaryDialog.exe" -Destination $stagingDir -Force
+          Copy-Item -Path "$dialogOutput/AutopilotMonitor.SummaryDialog.pdb" -Destination $stagingDir -Force -ErrorAction SilentlyContinue
+
+          # Create versioned ZIP for GitHub Release
+          $versionedZip = "AutopilotMonitor-Agent-v$version.zip"
+          Compress-Archive -Path "$stagingDir/*" -DestinationPath $versionedZip
+          Write-Host "Created release artifact: $versionedZip"
+
+          # Create deployment ZIP with fixed name for Blob Storage (matches bootstrap script download URL)
+          $deployZip = "AutopilotMonitor-Agent.zip"
+          Copy-Item $versionedZip $deployZip
+          Write-Host "Created deployment artifact: $deployZip"
 
           # Copy version.json for separate upload
-          Copy-Item "$sourcePath/version.json" "version.json"
+          Copy-Item "$agentOutput/version.json" "version.json"
+          Write-Host "version.json content: $(Get-Content version.json)"
 
-          "zip_name=$zipName" >> $env:GITHUB_OUTPUT
-        id: artifact
+          "versioned_zip=$versionedZip" >> $env:GITHUB_OUTPUT
+          "deploy_zip=$deployZip" >> $env:GITHUB_OUTPUT
+
+      - name: Upload to Azure Blob Storage
+        if: inputs.upload_blob
+        shell: pwsh
+        run: |
+          # Upload AutopilotMonitor-Agent.zip and version.json to blob container
+          $containerUrl = "https://autopilotmonitor.blob.core.windows.net/agent"
+          $sasToken = "${{ secrets.AZURE_BLOB_AGENT_SAS_TOKEN }}"
+
+          # Upload ZIP
+          $zipBlobUrl = "$containerUrl/AutopilotMonitor-Agent.zip?$sasToken"
+          $zipBytes = [System.IO.File]::ReadAllBytes("AutopilotMonitor-Agent.zip")
+          $zipHeaders = @{
+            "x-ms-blob-type" = "BlockBlob"
+            "Content-Type"   = "application/zip"
+          }
+          # Compute Content-MD5 for integrity validation (bootstrap script checks this header)
+          $md5 = [System.Security.Cryptography.MD5]::Create()
+          $md5Hash = [Convert]::ToBase64String($md5.ComputeHash($zipBytes))
+          $zipHeaders["Content-MD5"] = $md5Hash
+          $md5.Dispose()
+
+          Write-Host "Uploading AutopilotMonitor-Agent.zip ($([math]::Round($zipBytes.Length / 1MB, 2)) MB, MD5: $md5Hash)..."
+          Invoke-RestMethod -Uri $zipBlobUrl -Method Put -Headers $zipHeaders -Body $zipBytes
+          Write-Host "ZIP uploaded successfully"
+
+          # Upload version.json
+          $versionBlobUrl = "$containerUrl/version.json?$sasToken"
+          $versionContent = Get-Content "version.json" -Raw
+          $versionHeaders = @{
+            "x-ms-blob-type" = "BlockBlob"
+            "Content-Type"   = "application/json"
+          }
+          Write-Host "Uploading version.json: $versionContent"
+          Invoke-RestMethod -Uri $versionBlobUrl -Method Put -Headers $versionHeaders -Body $versionContent
+          Write-Host "version.json uploaded successfully"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: AutopilotMonitor-Agent-v${{ steps.version.outputs.version }}
-          path: ${{ steps.artifact.outputs.zip_name }}
+          path: ${{ steps.artifact.outputs.versioned_zip }}
 
       - name: Upload version metadata
         uses: actions/upload-artifact@v4
@@ -138,6 +208,11 @@ jobs:
             2. Extract to `C:\ProgramData\AutopilotMonitor\Agent\`
             3. Run `AutopilotMonitor.Agent.exe --install` to register the Scheduled Task
 
+            ### Included Components
+            - **AutopilotMonitor.Agent.exe** - Monitoring agent
+            - **AutopilotMonitor.SummaryDialog.exe** - Enrollment summary dialog (WPF)
+            - **version.json** - Version metadata for self-update
+
             ### Version Info
             - **Version:** ${{ steps.version.outputs.version }}
             - **Build Number:** ${{ steps.version.outputs.build_number }}
@@ -145,6 +220,6 @@ jobs:
           draft: false
           prerelease: ${{ inputs.prerelease }}
           files: |
-            ${{ steps.artifact.outputs.zip_name }}
+            ${{ steps.artifact.outputs.versioned_zip }}
             version.json
           generate_release_notes: true


### PR DESCRIPTION
## Summary
This PR introduces a new GitHub Actions workflow that automates the build, packaging, and release process for the Autopilot Monitor Agent. The workflow handles compilation of both the Agent and SummaryDialog components, version management, artifact creation, and deployment to Azure Blob Storage.

## Key Changes
- **New workflow file**: `.github/workflows/build-agent.yml` - Comprehensive CI/CD pipeline for Agent releases
- **Build automation**: Compiles `AutopilotMonitor.Agent` and `AutopilotMonitor.SummaryDialog` projects in Release configuration
- **Version management**: 
  - Auto-increments build numbers from `buildcounter.txt`
  - Supports manual build number override via workflow input
  - Reads version prefix from project file to construct semantic version
- **Artifact packaging**: Creates both versioned ZIP (for GitHub Releases) and fixed-name ZIP (for Blob Storage deployment)
- **Azure Blob Storage integration**: Uploads compiled agent ZIP and version.json with MD5 hash validation
- **GitHub Release creation**: Automatically creates releases with installation instructions and version metadata
- **Configurable workflow inputs**: Allows control over blob upload, release creation, and prerelease status

## Notable Implementation Details
- Workflow runs on Windows (required for .NET Framework 4.8 builds)
- Combines output from two separate projects into a single deployment package
- Includes integrity validation via Content-MD5 header for blob uploads
- Automatically commits and pushes build counter updates when auto-incrementing
- Generates comprehensive release notes with installation instructions and component details
- Uploads both versioned and unversioned artifacts for different deployment scenarios

https://claude.ai/code/session_01QiuThUkeSEbiapFpTY9yRp