### PR TITLE
Fix CVE version filtering to exclude already-fixed vulnerabilities

### DIFF
--- a/rules/dist/cpe-mapping-seed.json
+++ b/rules/dist/cpe-mapping-seed.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.1.0",
-  "lastUpdated": "2026-03-21",
+  "version": "1.2.0",
+  "lastUpdated": "2026-03-28",
   "mappings": [
     {
       "normalizedVendor": "google",
@@ -831,6 +831,66 @@
       "cpeProduct": "endpoint_configuration_manager",
       "cpeUri": "cpe:2.3:a:microsoft:endpoint_configuration_manager",
       "category": "enterprise"
+    },
+    {
+      "normalizedVendor": "microsoft",
+      "normalizedProduct": "microsoft intune management extension",
+      "displayNamePatterns": ["microsoft intune management extension", "intune management extension"],
+      "publisherPatterns": ["microsoft", "microsoft corporation"],
+      "cpeVendor": "microsoft",
+      "cpeProduct": "intune_management_extension",
+      "cpeUri": "cpe:2.3:a:microsoft:intune_management_extension",
+      "category": "enterprise"
+    },
+    {
+      "normalizedVendor": "microsoft",
+      "normalizedProduct": "company portal",
+      "displayNamePatterns": ["company portal", "microsoft company portal", "intune company portal"],
+      "publisherPatterns": ["microsoft", "microsoft corporation"],
+      "cpeVendor": "microsoft",
+      "cpeProduct": "company_portal",
+      "cpeUri": "cpe:2.3:a:microsoft:company_portal",
+      "category": "enterprise"
+    },
+    {
+      "normalizedVendor": "microsoft",
+      "normalizedProduct": "microsoft odbc driver for sql server",
+      "displayNamePatterns": ["microsoft odbc driver", "odbc driver 17 for sql server", "odbc driver 18 for sql server"],
+      "publisherPatterns": ["microsoft", "microsoft corporation"],
+      "cpeVendor": "microsoft",
+      "cpeProduct": "odbc_driver_for_sql_server",
+      "cpeUri": "cpe:2.3:a:microsoft:odbc_driver_for_sql_server",
+      "category": "database"
+    },
+    {
+      "normalizedVendor": "microsoft",
+      "normalizedProduct": "microsoft ole db driver for sql server",
+      "displayNamePatterns": ["microsoft ole db driver for sql server", "msoledbsql"],
+      "publisherPatterns": ["microsoft", "microsoft corporation"],
+      "cpeVendor": "microsoft",
+      "cpeProduct": "ole_db_driver_for_sql_server",
+      "cpeUri": "cpe:2.3:a:microsoft:ole_db_driver_for_sql_server",
+      "category": "database"
+    },
+    {
+      "normalizedVendor": "microsoft",
+      "normalizedProduct": "remote desktop client",
+      "displayNamePatterns": ["remote desktop", "microsoft remote desktop", "msrdc"],
+      "publisherPatterns": ["microsoft", "microsoft corporation"],
+      "cpeVendor": "microsoft",
+      "cpeProduct": "remote_desktop",
+      "cpeUri": "cpe:2.3:a:microsoft:remote_desktop",
+      "category": "utility"
+    },
+    {
+      "normalizedVendor": "microsoft",
+      "normalizedProduct": "azure cli",
+      "displayNamePatterns": ["microsoft azure cli", "azure cli", "microsoft cli"],
+      "publisherPatterns": ["microsoft", "microsoft corporation"],
+      "cpeVendor": "microsoft",
+      "cpeProduct": "azure_cli",
+      "cpeUri": "cpe:2.3:a:microsoft:azure_cli",
+      "category": "development"
     },
     {
       "normalizedVendor": "hcl",

--- a/src/Backend/AutopilotMonitor.Functions/Services/Vulnerability/VulnerabilityCorrelationService.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/Vulnerability/VulnerabilityCorrelationService.cs
@@ -535,14 +535,31 @@ namespace AutopilotMonitor.Functions.Services.Vulnerability
 
                 foreach (var range in cve.AffectedVersions)
                 {
-                    // If no version constraints, wildcard match only if CPE criteria matches our product
+                    // If no version range constraints, check whether the CPE criteria
+                    // contains a specific version or is a true wildcard (* or -).
                     if (string.IsNullOrWhiteSpace(range.VersionStartIncluding) &&
                         string.IsNullOrWhiteSpace(range.VersionStartExcluding) &&
                         string.IsNullOrWhiteSpace(range.VersionEndIncluding) &&
                         string.IsNullOrWhiteSpace(range.VersionEndExcluding))
                     {
                         if (range.Criteria != null && range.Criteria.StartsWith(cpeUri, StringComparison.OrdinalIgnoreCase))
-                            isAffected = true;
+                        {
+                            // Extract version from CPE 2.3 URI (field index 5):
+                            // cpe:2.3:part:vendor:product:VERSION:update:edition:...
+                            var cpeParts = range.Criteria.Split(':');
+                            var cpeVersion = cpeParts.Length > 5 ? cpeParts[5] : "*";
+
+                            if (cpeVersion == "*" || cpeVersion == "-" || string.IsNullOrWhiteSpace(cpeVersion))
+                            {
+                                // True wildcard — affects all versions of this product
+                                isAffected = true;
+                            }
+                            else if (!string.IsNullOrWhiteSpace(installedVersion))
+                            {
+                                // Exact version in CPE — only affected if installed version matches
+                                isAffected = VersionComparer.Compare(installedVersion, cpeVersion) == 0;
+                            }
+                        }
                     }
                     else if (!string.IsNullOrWhiteSpace(installedVersion))
                     {


### PR DESCRIPTION
The FilterByVersion wildcard logic was treating CVEs with specific
versions in their CPE URI as affecting ALL versions. Now extracts the
version from the CPE 2.3 URI and compares it against the installed
version, so only truly relevant CVEs are shown.

Also adds missing CPE seed mappings for common Intune/Autopilot
managed software: Intune Management Extension, Company Portal,
ODBC/OLE DB drivers, Remote Desktop, Azure CLI.

https://claude.ai/code/session_01Kv2aAEVqbeFSsyPv7gU7pF