### PR TITLE
fix(agent): V2 hotfix #2 — wire remote config + reorder Transport subscription

### DIFF
--- a/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Configuration/RemoteConfigMergerTests.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Configuration/RemoteConfigMergerTests.cs
@@ -1,0 +1,371 @@
+using System;
+using System.Collections.Generic;
+using AutopilotMonitor.Agent.V2.Core.Configuration;
+using AutopilotMonitor.Agent.V2.Core.Logging;
+using AutopilotMonitor.Shared.Models;
+using Xunit;
+
+namespace AutopilotMonitor.Agent.V2.Core.Tests.Configuration
+{
+    /// <summary>
+    /// Tests for <see cref="RemoteConfigMerger"/>. This merger is the single source of
+    /// Legacy-parity: every field delivered by the backend that has a live V2 consumer must
+    /// land on <see cref="AgentConfiguration"/> after <c>FetchConfigAsync</c>.
+    /// </summary>
+    public sealed class RemoteConfigMergerTests
+    {
+        private static AgentConfiguration NewAgentConfig() => new AgentConfiguration
+        {
+            ApiBaseUrl = "https://example",
+            TenantId = "t",
+            SessionId = "s",
+        };
+
+        private static AgentConfigResponse FullRemote() => new AgentConfigResponse
+        {
+            ConfigVersion = 26,
+            UploadIntervalSeconds = 45,
+            MaxBatchSize = 250,
+            SelfDestructOnComplete = false,
+            KeepLogFile = true,
+            EnableGeoLocation = false,
+            RebootOnComplete = true,
+            RebootDelaySeconds = 30,
+            ShowEnrollmentSummary = true,
+            EnrollmentSummaryTimeoutSeconds = 90,
+            EnrollmentSummaryBrandingImageUrl = "https://cdn.example/logo.png",
+            EnrollmentSummaryLaunchRetrySeconds = 300,
+            NtpServer = "pool.ntp.org",
+            EnableTimezoneAutoSet = true,
+            DiagnosticsUploadEnabled = true,
+            DiagnosticsUploadMode = "OnFailure",
+            DiagnosticsLogPaths = new List<DiagnosticsLogPath>
+            {
+                new DiagnosticsLogPath { Path = @"%ProgramData%\Foo\*.log", IsBuiltIn = false },
+            },
+            LogLevel = "Debug",
+            SendTraceEvents = false,
+            UnrestrictedMode = true,
+            Collectors = new CollectorConfiguration
+            {
+                AgentMaxLifetimeMinutes = 120,
+                HelloWaitTimeoutSeconds = 45,
+            },
+        };
+
+        // ============================================================= Happy path
+
+        [Fact]
+        public void Merge_applies_all_tenant_fields_when_no_cli_overrides()
+        {
+            var agent = NewAgentConfig();
+            var remote = FullRemote();
+
+            RemoteConfigMerger.Merge(agent, remote, Array.Empty<string>());
+
+            Assert.False(agent.SelfDestructOnComplete);
+            Assert.True(agent.KeepLogFile);
+            Assert.False(agent.EnableGeoLocation);
+            Assert.True(agent.RebootOnComplete);
+            Assert.Equal(30, agent.RebootDelaySeconds);
+            Assert.True(agent.ShowEnrollmentSummary);
+            Assert.Equal(90, agent.EnrollmentSummaryTimeoutSeconds);
+            Assert.Equal("https://cdn.example/logo.png", agent.EnrollmentSummaryBrandingImageUrl);
+            Assert.Equal(300, agent.EnrollmentSummaryLaunchRetrySeconds);
+            Assert.Equal("pool.ntp.org", agent.NtpServer);
+            Assert.True(agent.EnableTimezoneAutoSet);
+            Assert.True(agent.DiagnosticsUploadEnabled);
+            Assert.Equal("OnFailure", agent.DiagnosticsUploadMode);
+            Assert.Single(agent.DiagnosticsLogPaths);
+            Assert.Equal(@"%ProgramData%\Foo\*.log", agent.DiagnosticsLogPaths[0].Path);
+            Assert.Equal(AgentLogLevel.Debug, agent.LogLevel);
+            Assert.False(agent.SendTraceEvents);
+            Assert.True(agent.UnrestrictedMode);
+            Assert.Equal(45, agent.UploadIntervalSeconds);
+            Assert.Equal(250, agent.MaxBatchSize);
+            Assert.Equal(120, agent.AgentMaxLifetimeMinutes);
+            Assert.Equal(45, agent.HelloWaitTimeoutSeconds);
+        }
+
+        // ============================================================= CLI override wins
+
+        [Fact]
+        public void Merge_preserves_no_cleanup_cli_flag_over_remote_true()
+        {
+            var agent = NewAgentConfig();
+            agent.SelfDestructOnComplete = false; // as set by BuildAgentConfiguration when CLI had --no-cleanup
+
+            var remote = FullRemote();
+            remote.SelfDestructOnComplete = true; // tenant enabled cleanup, dev disabled locally
+
+            RemoteConfigMerger.Merge(agent, remote, new[] { "--no-cleanup" });
+
+            Assert.False(agent.SelfDestructOnComplete);
+        }
+
+        [Fact]
+        public void Merge_preserves_keep_logfile_cli_flag_over_remote_false()
+        {
+            var agent = NewAgentConfig();
+            agent.KeepLogFile = true;
+
+            var remote = FullRemote();
+            remote.KeepLogFile = false;
+
+            RemoteConfigMerger.Merge(agent, remote, new[] { "--keep-logfile" });
+
+            Assert.True(agent.KeepLogFile);
+        }
+
+        [Fact]
+        public void Merge_preserves_reboot_cli_flag_over_remote_false()
+        {
+            var agent = NewAgentConfig();
+            agent.RebootOnComplete = true;
+
+            var remote = FullRemote();
+            remote.RebootOnComplete = false;
+
+            RemoteConfigMerger.Merge(agent, remote, new[] { "--reboot-on-complete" });
+
+            Assert.True(agent.RebootOnComplete);
+        }
+
+        [Fact]
+        public void Merge_preserves_disable_geolocation_cli_flag_over_remote_true()
+        {
+            var agent = NewAgentConfig();
+            agent.EnableGeoLocation = false;
+
+            var remote = FullRemote();
+            remote.EnableGeoLocation = true;
+
+            RemoteConfigMerger.Merge(agent, remote, new[] { "--disable-geolocation" });
+
+            Assert.False(agent.EnableGeoLocation);
+        }
+
+        [Fact]
+        public void Merge_preserves_log_level_cli_arg_over_remote_string()
+        {
+            var agent = NewAgentConfig();
+            agent.LogLevel = AgentLogLevel.Verbose;
+
+            var remote = FullRemote();
+            remote.LogLevel = "Debug";
+
+            RemoteConfigMerger.Merge(agent, remote, new[] { "--log-level", "Verbose" });
+
+            Assert.Equal(AgentLogLevel.Verbose, agent.LogLevel);
+        }
+
+        [Fact]
+        public void Merge_parses_remote_log_level_case_insensitive()
+        {
+            var agent = NewAgentConfig();
+            var remote = FullRemote();
+            remote.LogLevel = "trace";
+
+            RemoteConfigMerger.Merge(agent, remote, Array.Empty<string>());
+
+            Assert.Equal(AgentLogLevel.Trace, agent.LogLevel);
+        }
+
+        [Fact]
+        public void Merge_keeps_log_level_when_remote_value_is_unparseable()
+        {
+            var agent = NewAgentConfig();
+            agent.LogLevel = AgentLogLevel.Info;
+
+            var remote = FullRemote();
+            remote.LogLevel = "NotAValidLevel";
+
+            RemoteConfigMerger.Merge(agent, remote, Array.Empty<string>());
+
+            Assert.Equal(AgentLogLevel.Info, agent.LogLevel);
+        }
+
+        // ============================================================= Null / partial tolerance
+
+        [Fact]
+        public void Merge_ignores_null_remote_config()
+        {
+            var agent = NewAgentConfig();
+            agent.NtpServer = "local.ntp";
+            agent.SelfDestructOnComplete = true;
+
+            RemoteConfigMerger.Merge(agent, null!, Array.Empty<string>());
+
+            Assert.Equal("local.ntp", agent.NtpServer);
+            Assert.True(agent.SelfDestructOnComplete);
+        }
+
+        [Fact]
+        public void Merge_accepts_null_cli_args()
+        {
+            var agent = NewAgentConfig();
+            var remote = FullRemote();
+
+            RemoteConfigMerger.Merge(agent, remote, null!);
+
+            Assert.False(agent.SelfDestructOnComplete);
+            Assert.Equal("pool.ntp.org", agent.NtpServer);
+        }
+
+        [Fact]
+        public void Merge_tolerates_null_nested_collectors()
+        {
+            var agent = NewAgentConfig();
+            agent.AgentMaxLifetimeMinutes = 360;
+            agent.HelloWaitTimeoutSeconds = 30;
+
+            var remote = FullRemote();
+            remote.Collectors = null!;
+
+            RemoteConfigMerger.Merge(agent, remote, Array.Empty<string>());
+
+            Assert.Equal(360, agent.AgentMaxLifetimeMinutes);
+            Assert.Equal(30, agent.HelloWaitTimeoutSeconds);
+        }
+
+        [Fact]
+        public void Merge_keeps_default_ntp_server_when_remote_is_empty()
+        {
+            var agent = NewAgentConfig();
+            agent.NtpServer = "time.windows.com";
+
+            var remote = FullRemote();
+            remote.NtpServer = "";
+
+            RemoteConfigMerger.Merge(agent, remote, Array.Empty<string>());
+
+            Assert.Equal("time.windows.com", agent.NtpServer);
+        }
+
+        [Fact]
+        public void Merge_keeps_default_diagnostics_mode_when_remote_is_null()
+        {
+            var agent = NewAgentConfig();
+            agent.DiagnosticsUploadMode = "Off";
+
+            var remote = FullRemote();
+            remote.DiagnosticsUploadMode = null!;
+
+            RemoteConfigMerger.Merge(agent, remote, Array.Empty<string>());
+
+            Assert.Equal("Off", agent.DiagnosticsUploadMode);
+        }
+
+        [Fact]
+        public void Merge_replaces_diagnostics_log_paths_with_empty_list_when_remote_null()
+        {
+            var agent = NewAgentConfig();
+            agent.DiagnosticsLogPaths = new List<DiagnosticsLogPath>
+            {
+                new DiagnosticsLogPath { Path = "stale", IsBuiltIn = false },
+            };
+
+            var remote = FullRemote();
+            remote.DiagnosticsLogPaths = null!;
+
+            RemoteConfigMerger.Merge(agent, remote, Array.Empty<string>());
+
+            Assert.NotNull(agent.DiagnosticsLogPaths);
+            Assert.Empty(agent.DiagnosticsLogPaths);
+        }
+
+        // ============================================================= Int clamping
+
+        [Fact]
+        public void Merge_skips_non_positive_upload_interval()
+        {
+            var agent = NewAgentConfig();
+            agent.UploadIntervalSeconds = 30;
+
+            var remote = FullRemote();
+            remote.UploadIntervalSeconds = 0;
+
+            RemoteConfigMerger.Merge(agent, remote, Array.Empty<string>());
+
+            Assert.Equal(30, agent.UploadIntervalSeconds);
+        }
+
+        [Fact]
+        public void Merge_skips_non_positive_max_batch_size()
+        {
+            var agent = NewAgentConfig();
+            agent.MaxBatchSize = 100;
+
+            var remote = FullRemote();
+            remote.MaxBatchSize = -1;
+
+            RemoteConfigMerger.Merge(agent, remote, Array.Empty<string>());
+
+            Assert.Equal(100, agent.MaxBatchSize);
+        }
+
+        [Fact]
+        public void Merge_skips_non_positive_hello_wait_timeout()
+        {
+            var agent = NewAgentConfig();
+            agent.HelloWaitTimeoutSeconds = 30;
+
+            var remote = FullRemote();
+            remote.Collectors = new CollectorConfiguration
+            {
+                AgentMaxLifetimeMinutes = 360,
+                HelloWaitTimeoutSeconds = 0,
+            };
+
+            RemoteConfigMerger.Merge(agent, remote, Array.Empty<string>());
+
+            Assert.Equal(30, agent.HelloWaitTimeoutSeconds);
+        }
+
+        [Fact]
+        public void Merge_allows_zero_agent_max_lifetime_to_disable_watchdog()
+        {
+            var agent = NewAgentConfig();
+            agent.AgentMaxLifetimeMinutes = 360;
+
+            var remote = FullRemote();
+            remote.Collectors = new CollectorConfiguration
+            {
+                AgentMaxLifetimeMinutes = 0, // explicit "disabled"
+                HelloWaitTimeoutSeconds = 30,
+            };
+
+            RemoteConfigMerger.Merge(agent, remote, Array.Empty<string>());
+
+            Assert.Equal(0, agent.AgentMaxLifetimeMinutes);
+        }
+
+        // ============================================================= Guard
+
+        [Fact]
+        public void Merge_throws_on_null_agent_config()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                RemoteConfigMerger.Merge(null!, FullRemote(), Array.Empty<string>()));
+        }
+
+        // ============================================================= The user's scenario
+
+        [Fact]
+        public void Merge_flips_self_destruct_off_when_tenant_admin_disables_cleanup_and_agent_runs_without_cli_args()
+        {
+            // Regression guard for the VM smoke-test bug: tenant config has SelfDestructOnComplete=false
+            // but agent was built with CLI-default true, and without the merger the remote value never
+            // reached CleanupService / EnrollmentTerminationHandler.
+            var agent = NewAgentConfig();
+            agent.SelfDestructOnComplete = true; // BuildAgentConfiguration CLI-default when no --no-cleanup
+
+            var remote = FullRemote();
+            remote.SelfDestructOnComplete = false;
+
+            RemoteConfigMerger.Merge(agent, remote, Array.Empty<string>());
+
+            Assert.False(agent.SelfDestructOnComplete);
+        }
+    }
+}

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Orchestration/EnrollmentOrchestratorTests.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Orchestration/EnrollmentOrchestratorTests.cs
@@ -94,6 +94,19 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Orchestration
             Assert.Throws<InvalidOperationException>(() => sut.CurrentState);
             Assert.Throws<InvalidOperationException>(() => sut.IngressSink);
             Assert.Throws<InvalidOperationException>(() => sut.EventEmitter);
+            // Regression guard: Program.WireTelemetryServerResponse must run AFTER Start().
+            // Touching Transport pre-Start threw InvalidOperationException and crashed the agent
+            // on every VM after the first-run-ghost-detect fix let it reach this far.
+            Assert.Throws<InvalidOperationException>(() => sut.Transport);
+        }
+
+        [Fact]
+        public void Transport_is_available_after_start()
+        {
+            using var rig = new Rig();
+            var sut = rig.Build();
+            sut.Start();
+            Assert.NotNull(sut.Transport);
         }
 
         // ========================================================================= Start

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Configuration/RemoteConfigMerger.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Configuration/RemoteConfigMerger.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using AutopilotMonitor.Agent.V2.Core.Logging;
+using AutopilotMonitor.Shared.Models;
+
+namespace AutopilotMonitor.Agent.V2.Core.Configuration
+{
+    /// <summary>
+    /// Projects the remote <see cref="AgentConfigResponse"/> onto the runtime
+    /// <see cref="AgentConfiguration"/>. Before this merger existed the agent fetched the remote
+    /// config and stored it internally in <see cref="RemoteConfigService.CurrentConfig"/>, but
+    /// only <c>Collectors</c>, <c>ImeLogPatterns</c>, <c>GatherRules</c>,
+    /// <c>WhiteGloveSealingPatternIds</c> and <c>LatestAgentSha256</c> were consumed downstream.
+    /// All other tenant-controlled knobs — <c>SelfDestructOnComplete</c>, <c>KeepLogFile</c>,
+    /// <c>NtpServer</c>, <c>DiagnosticsUploadMode</c>, <c>ShowEnrollmentSummary</c>, the reboot
+    /// policy, the log level, the lifetime watchdog and the guardrail-relax switch — were bound
+    /// to <see cref="AgentConfiguration"/> defaults set from CLI / bootstrap-config, so tenant
+    /// admin settings were effectively ignored.
+    /// <para>
+    /// CLI-override semantics: command-line flags that were explicitly passed take precedence
+    /// over the remote value. In production (Scheduled Task run with no args) the remote value
+    /// always wins; in local dev runs the developer can still force a specific behaviour with
+    /// a CLI flag without their tenant remote config clobbering it.
+    /// </para>
+    /// </summary>
+    public static class RemoteConfigMerger
+    {
+        /// <summary>
+        /// Overwrites the relevant <paramref name="agentConfig"/> fields with values from
+        /// <paramref name="remoteConfig"/>. Unknown / null / empty remote fields keep the
+        /// current <paramref name="agentConfig"/> value (partial-remote-config tolerance).
+        /// </summary>
+        public static void Merge(
+            AgentConfiguration agentConfig,
+            AgentConfigResponse remoteConfig,
+            string[] cliArgs)
+        {
+            if (agentConfig == null) throw new ArgumentNullException(nameof(agentConfig));
+            if (remoteConfig == null) return;
+            cliArgs = cliArgs ?? Array.Empty<string>();
+
+            // ---- Boolean flags that have a matching CLI override — CLI wins when present.
+            if (!ContainsFlag(cliArgs, "--no-cleanup"))
+                agentConfig.SelfDestructOnComplete = remoteConfig.SelfDestructOnComplete;
+            if (!ContainsFlag(cliArgs, "--keep-logfile"))
+                agentConfig.KeepLogFile = remoteConfig.KeepLogFile;
+            if (!ContainsFlag(cliArgs, "--reboot-on-complete"))
+                agentConfig.RebootOnComplete = remoteConfig.RebootOnComplete;
+            if (!ContainsFlag(cliArgs, "--disable-geolocation"))
+                agentConfig.EnableGeoLocation = remoteConfig.EnableGeoLocation;
+
+            // ---- Log level — CLI `--log-level <value>` wins. Remote is a string that may not parse.
+            if (!ContainsValueArg(cliArgs, "--log-level")
+                && !string.IsNullOrWhiteSpace(remoteConfig.LogLevel)
+                && Enum.TryParse<AgentLogLevel>(remoteConfig.LogLevel, ignoreCase: true, out var parsedLevel))
+            {
+                agentConfig.LogLevel = parsedLevel;
+            }
+
+            // ---- Fields without a CLI override — always apply remote.
+            agentConfig.RebootDelaySeconds = remoteConfig.RebootDelaySeconds;
+            agentConfig.ShowEnrollmentSummary = remoteConfig.ShowEnrollmentSummary;
+            agentConfig.EnrollmentSummaryTimeoutSeconds = remoteConfig.EnrollmentSummaryTimeoutSeconds;
+            agentConfig.EnrollmentSummaryBrandingImageUrl = remoteConfig.EnrollmentSummaryBrandingImageUrl;
+            agentConfig.EnrollmentSummaryLaunchRetrySeconds = remoteConfig.EnrollmentSummaryLaunchRetrySeconds;
+
+            if (!string.IsNullOrWhiteSpace(remoteConfig.NtpServer))
+                agentConfig.NtpServer = remoteConfig.NtpServer;
+            agentConfig.EnableTimezoneAutoSet = remoteConfig.EnableTimezoneAutoSet;
+
+            agentConfig.DiagnosticsUploadEnabled = remoteConfig.DiagnosticsUploadEnabled;
+            if (!string.IsNullOrWhiteSpace(remoteConfig.DiagnosticsUploadMode))
+                agentConfig.DiagnosticsUploadMode = remoteConfig.DiagnosticsUploadMode;
+            agentConfig.DiagnosticsLogPaths = remoteConfig.DiagnosticsLogPaths ?? new List<DiagnosticsLogPath>();
+
+            agentConfig.SendTraceEvents = remoteConfig.SendTraceEvents;
+            agentConfig.UnrestrictedMode = remoteConfig.UnrestrictedMode;
+
+            // ---- Positive-only int knobs — a zero or negative remote value keeps the current default.
+            if (remoteConfig.UploadIntervalSeconds > 0)
+                agentConfig.UploadIntervalSeconds = remoteConfig.UploadIntervalSeconds;
+            if (remoteConfig.MaxBatchSize > 0)
+                agentConfig.MaxBatchSize = remoteConfig.MaxBatchSize;
+
+            // ---- Nested: CollectorConfiguration. Only the fields that have a V2 consumer
+            //      on AgentConfiguration are projected here; the rest flow directly from
+            //      remoteConfig.Collectors via DefaultComponentFactory.
+            var collectors = remoteConfig.Collectors;
+            if (collectors != null)
+            {
+                // AgentMaxLifetimeMinutes: 0 = disabled (valid); passed to the orchestrator as a TimeSpan?.
+                agentConfig.AgentMaxLifetimeMinutes = collectors.AgentMaxLifetimeMinutes;
+                if (collectors.HelloWaitTimeoutSeconds > 0)
+                    agentConfig.HelloWaitTimeoutSeconds = collectors.HelloWaitTimeoutSeconds;
+            }
+        }
+
+        private static bool ContainsFlag(string[] args, string flag)
+        {
+            for (int i = 0; i < args.Length; i++)
+                if (string.Equals(args[i], flag, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            return false;
+        }
+
+        private static bool ContainsValueArg(string[] args, string flag)
+        {
+            // Value-args need both the flag and a subsequent token, otherwise the CLI helper would
+            // not have parsed them — mirror GetArgValue's "i < args.Length - 1" contract.
+            for (int i = 0; i < args.Length - 1; i++)
+                if (string.Equals(args[i], flag, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            return false;
+        }
+    }
+}

--- a/src/Agent/AutopilotMonitor.Agent.V2/Program.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2/Program.cs
@@ -310,6 +310,12 @@ namespace AutopilotMonitor.Agent.V2
                 backendApiClient, agentConfig.TenantId, logger, emergencyReporter, distressReporter);
             var remoteConfig = remoteConfigService.FetchConfigAsync().GetAwaiter().GetResult();
 
+            // Project remote tenant-controlled knobs onto the runtime AgentConfiguration so that
+            // downstream consumers (CleanupService, SummaryDialogLauncher, StartupEnvironmentProbes,
+            // DiagnosticsPackageService, EnrollmentTerminationHandler, the logger, the watchdog)
+            // actually respect the tenant admin settings. CLI flags stay authoritative over remote.
+            RemoteConfigMerger.Merge(agentConfig, remoteConfig, args);
+
             logger.SetLogLevel(agentConfig.LogLevel);
 
             // Propagate the backend-expected SHA so the runtime hash-mismatch trigger (M4.6.α
@@ -476,14 +482,6 @@ namespace AutopilotMonitor.Agent.V2
                         },
                         emitEvent: evt => { orchestrator.EventEmitter.Emit(evt); });
 
-                    // M4.6.ε — BackendTelemetryUploader response-plumbing. The orchestrator parses
-                    // DeviceBlocked / DeviceKillSignal / AdminAction / Actions out of the 2xx
-                    // response body (see BackendTelemetryUploader.TryReadControlSignalsAsync) and
-                    // raises ServerResponseReceived. We translate those into ServerActions and
-                    // dispatch. Legacy parity with IngestEventsResponse synthesis in
-                    // EventUploadOrchestrator.OnEventsUploaded().
-                    WireTelemetryServerResponse(orchestrator, serverActionDispatcher, logger);
-
                     ConsoleCancelEventHandler cancelHandler = (s, e) =>
                     {
                         e.Cancel = true;
@@ -503,6 +501,18 @@ namespace AutopilotMonitor.Agent.V2
                     try
                     {
                         orchestrator.Start();
+
+                        // M4.6.ε — BackendTelemetryUploader response-plumbing. The orchestrator parses
+                        // DeviceBlocked / DeviceKillSignal / AdminAction / Actions out of the 2xx
+                        // response body (see BackendTelemetryUploader.TryReadControlSignalsAsync) and
+                        // raises ServerResponseReceived. We translate those into ServerActions and
+                        // dispatch. Legacy parity with IngestEventsResponse synthesis in
+                        // EventUploadOrchestrator.OnEventsUploaded().
+                        //
+                        // MUST be wired AFTER Start() — orchestrator.Transport throws
+                        // InvalidOperationException before Start() because the
+                        // TelemetryUploadOrchestrator is constructed inside Start() at step 311.
+                        WireTelemetryServerResponse(orchestrator, serverActionDispatcher, logger);
 
                         // Emit the agent_version_check event now that the EventEmitter is alive.
                         // VersionCheckEventBuilder.TryBuild is a no-op when no markers are present.


### PR DESCRIPTION
## Summary

Two V2 agent bugs surfaced in the VM smoke-test after PR #44 let the agent reach the backend fetch phase for the first time:

1. **Init-order crash** — `Program.WireTelemetryServerResponse` touched `orchestrator.Transport` before `orchestrator.Start()`, which throws `InvalidOperationException` pre-Start because the `TelemetryUploadOrchestrator` is only constructed inside `Start()` at `EnrollmentOrchestrator.cs:311`. Every VM crashed at this exact line. Fix: move the wire call to immediately after `orchestrator.Start()` inside the same try block.

2. **Remote-config wiring gap** — `RemoteConfigService` fetched `AgentConfigResponse` from the backend but only `Collectors`, `ImeLogPatterns`, `GatherRules`, `WhiteGloveSealingPatternIds` and `LatestAgentSha256` were ever consumed downstream. **~20 tenant-controlled fields** on the DTO were bound to `AgentConfiguration` defaults from CLI / bootstrap-config and never got projected from the remote response. Every consumer site (`CleanupService`, `SummaryDialogLauncher`, `StartupEnvironmentProbes`, `DiagnosticsPackageService`, `EnrollmentTerminationHandler`, `AgentLogger`, `EnrollmentOrchestrator`, `GatherRuleGuards`) reads `agentConfig.XXX`, so tenant admin settings were effectively ignored in Prod.

A tenant with `SelfDestructOnComplete=false` still saw its agent wipe `%ProgramData%` on enrollment complete, because the CLI-default `!noCleanup=true` always won.

## Fields now wired via `RemoteConfigMerger`

`SelfDestructOnComplete`, `KeepLogFile`, `RebootOnComplete`, `RebootDelaySeconds`, `ShowEnrollmentSummary`, `EnrollmentSummaryTimeoutSeconds`, `EnrollmentSummaryBrandingImageUrl`, `EnrollmentSummaryLaunchRetrySeconds`, `NtpServer`, `EnableTimezoneAutoSet`, `EnableGeoLocation`, `DiagnosticsUploadEnabled`, `DiagnosticsUploadMode`, `DiagnosticsLogPaths`, `LogLevel`, `UploadIntervalSeconds`, `MaxBatchSize`, `SendTraceEvents`, `UnrestrictedMode`, nested `Collectors.AgentMaxLifetimeMinutes`, nested `Collectors.HelloWaitTimeoutSeconds`.

## CLI override semantics preserved

The merger respects CLI flags that are explicitly passed: `--no-cleanup`, `--keep-logfile`, `--reboot-on-complete`, `--disable-geolocation`, `--log-level`. Local dev runs keep their ad-hoc overrides; Prod (Scheduled Task run without args) gets full remote control.

## Partial-remote-config tolerance

Empty strings, null lists and non-positive ints keep the `AgentConfiguration` default. Null `remoteConfig` or null `cliArgs` are tolerated gracefully. A null nested `Collectors` does not reset the watchdog fields.

## Fields deliberately **not** mapped

`MaxAuthFailures`, `AuthFailureTimeoutMinutes`, `LatestAgentExeSha256`, `EnableImeMatchLog` — these are DTO-only in V1 too (verified: zero consumer sites in `src/Agent/AutopilotMonitor.Agent/`). Not mapping them is V1-parity, not a regression.

## Test coverage

- `EnrollmentOrchestratorTests`: `Transport` pre-`Start()` now explicitly asserted to throw (regression guard so any future pre-Start consumer is caught in CI); new `Transport_is_available_after_start` confirms the post-Start happy path.
- `RemoteConfigMergerTests` (20 tests):
  - Happy path: all fields apply when no CLI overrides
  - 5 CLI-override tests
  - `LogLevel` case-insensitivity + parse-failure-preserves-default
  - Null-remote-config / null-cli-args / null-nested-Collectors tolerance
  - Empty-string `NtpServer` + null `DiagnosticsUploadMode` keep defaults
  - Null `DiagnosticsLogPaths` becomes empty list (not null)
  - Non-positive int clamping (`UploadIntervalSeconds`, `MaxBatchSize`, `HelloWaitTimeoutSeconds`)
  - Zero `AgentMaxLifetimeMinutes` allowed (explicit "disabled")
  - Null-agent-config argument guard
  - Regression test for the exact VM scenario

**446 / 446 V2.Core tests green.**

## Test plan

- [x] Build `AutopilotMonitor.Agent.V2.csproj` — succeeds
- [x] Full V2.Core test suite — 446 / 446 passing
- [ ] Rebuild V2 agent binary, re-deploy to test VM via Intune, confirm `/api/agent/telemetry` hits backend + Signals/DecisionTransitions land + end-of-enrollment respects tenant `SelfDestructOnComplete=false` (logs survive)

## Rollout

- Merge to `main`
- User rebuilds the V2 agent ZIP, re-uploads to blob
- Intune assignment-refresh on test VM picks up the new binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)