### PR TITLE
feat(backend,mcp): opt-in pagination on config/all to fix list_tenant…

### DIFF
--- a/src/Backend/AutopilotMonitor.Functions.Tests/TenantConfigPaginationTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/TenantConfigPaginationTests.cs
@@ -1,0 +1,130 @@
+using System.Collections.Specialized;
+using AutopilotMonitor.Functions.Pagination;
+using AutopilotMonitor.Shared.Pagination;
+
+namespace AutopilotMonitor.Functions.Tests;
+
+/// <summary>
+/// Opt-in pagination wiring on <c>GET /api/config/all</c> (fixes the MCP
+/// list_tenants size-cap). The endpoint is GlobalAdminOnly with no filter
+/// params; when <c>pageSize</c> is absent the function returns the legacy
+/// unpaginated bare array, so these helpers only engage once a caller opts in.
+/// The continuation token binds to the caller's identity to block cross-caller
+/// replay of deep paginated bookmark links.
+/// </summary>
+public class TenantConfigPaginationTests
+{
+    private const string CallerTenant = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    private const string CallerTenantOther = "b2c3d4e5-f6a7-8901-bcde-f12345678901";
+
+    // ────────── ParseQuery ──────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseQuery_with_no_params_signals_unpaginated_mode()
+    {
+        var parsed = TenantConfigPagination.ParseQuery(new NameValueCollection());
+
+        Assert.Null(parsed.Error);
+        Assert.Null(parsed.PageSize);          // null PageSize → legacy bare-array path
+        Assert.Null(parsed.Continuation);
+    }
+
+    [Fact]
+    public void ParseQuery_with_pageSize_activates_pagination()
+    {
+        var parsed = TenantConfigPagination.ParseQuery(new NameValueCollection
+        {
+            { "pageSize", "100" },
+            { "continuation", "ENCODED" },
+        });
+
+        Assert.Null(parsed.Error);
+        Assert.Equal(100, parsed.PageSize);
+        Assert.Equal("ENCODED", parsed.Continuation);
+    }
+
+    [Fact]
+    public void ParseQuery_drops_continuation_when_pageSize_absent()
+    {
+        var parsed = TenantConfigPagination.ParseQuery(new NameValueCollection
+        {
+            { "continuation", "STALE" },
+        });
+
+        Assert.Null(parsed.PageSize);
+        Assert.Null(parsed.Continuation);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-5")]
+    [InlineData("1001")]
+    [InlineData("banana")]
+    public void ParseQuery_rejects_invalid_pageSize(string raw)
+    {
+        var parsed = TenantConfigPagination.ParseQuery(new NameValueCollection { { "pageSize", raw } });
+        Assert.NotNull(parsed.Error);
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("1000")]
+    public void ParseQuery_accepts_pageSize_bounds(string raw)
+    {
+        var parsed = TenantConfigPagination.ParseQuery(new NameValueCollection { { "pageSize", raw } });
+        Assert.Null(parsed.Error);
+        Assert.Equal(int.Parse(raw), parsed.PageSize);
+    }
+
+    // ────────── Token round-trip + cross-caller rejection ───────────────────
+
+    [Fact]
+    public void TryAcceptContinuation_round_trips_for_matching_caller()
+    {
+        var fp = TenantConfigPagination.Fingerprint(CallerTenant);
+        var encoded = ContinuationToken.Encode("rawAzure", CallerTenant, fp);
+
+        var ok = TenantConfigPagination.TryAcceptContinuation(
+            encoded, CallerTenant, out var azure, out var reason);
+
+        Assert.True(ok);
+        Assert.Null(reason);
+        Assert.Equal("rawAzure", azure);
+    }
+
+    [Fact]
+    public void TryAcceptContinuation_rejects_token_replayed_by_a_different_caller()
+    {
+        // A deep-page bookmark issued for caller A must not be replayable by caller B.
+        var fp = TenantConfigPagination.Fingerprint(CallerTenant);
+        var encoded = ContinuationToken.Encode("rawAzure", CallerTenant, fp);
+
+        var ok = TenantConfigPagination.TryAcceptContinuation(
+            encoded, CallerTenantOther, out _, out var reason);
+
+        Assert.False(ok);
+        Assert.Equal("cross_tenant", reason);
+    }
+
+    [Fact]
+    public void TryAcceptContinuation_rejects_garbage_token()
+    {
+        var ok = TenantConfigPagination.TryAcceptContinuation(
+            "not-a-real-token", CallerTenant, out _, out var reason);
+
+        Assert.False(ok);
+        Assert.NotNull(reason);
+    }
+
+    // ────────── BuildNextLink ───────────────────────────────────────────────
+
+    [Fact]
+    public void BuildNextLink_targets_config_all_with_pageSize_and_escaped_continuation()
+    {
+        var link = TenantConfigPagination.BuildNextLink(100, "TOKEN+/=");
+
+        Assert.StartsWith("/api/config/all?", link);
+        Assert.Contains("pageSize=100", link);
+        Assert.Contains("continuation=TOKEN%2B%2F%3D", link);
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions/DataAccess/TableStorage/TableConfigRepository.cs
+++ b/src/Backend/AutopilotMonitor.Functions/DataAccess/TableStorage/TableConfigRepository.cs
@@ -2,10 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using AutopilotMonitor.Functions.Pagination;
 using AutopilotMonitor.Functions.Services;
 using AutopilotMonitor.Shared;
 using AutopilotMonitor.Shared.DataAccess;
 using AutopilotMonitor.Shared.Models;
+using AutopilotMonitor.Shared.Pagination;
 using Azure;
 using Azure.Data.Tables;
 using Microsoft.Extensions.Logging;
@@ -88,6 +90,25 @@ namespace AutopilotMonitor.Functions.DataAccess.TableStorage
                 _logger.LogError(ex, "Error loading all tenant configurations");
                 throw;
             }
+        }
+
+        public async Task<RawPage<TenantConfiguration>> GetTenantConfigurationsPageAsync(int pageSize, string? continuation)
+        {
+            if (pageSize < 1) throw new ArgumentOutOfRangeException(nameof(pageSize));
+
+            // Cross-partition scan over the single 'config' row per tenant. Azure returns
+            // (PartitionKey asc, RowKey asc); PartitionKey == TenantId, so pages are already
+            // TenantId-ordered — a stable cursor without an in-memory re-sort (which would
+            // break pagination by only ordering the current page).
+            var (entities, nextRawToken) = await AzureTablesPaginator.FetchPageAsync<TableEntity>(
+                client: _tenantConfigTableClient,
+                filter: "RowKey eq 'config'",
+                pageSize: pageSize,
+                continuation: continuation);
+
+            var configurations = new List<TenantConfiguration>(entities.Count);
+            foreach (var entity in entities) configurations.Add(ConvertFromTenantTableEntity(entity));
+            return new RawPage<TenantConfiguration>(configurations, nextRawToken);
         }
 
         // --- Admin Configuration ---

--- a/src/Backend/AutopilotMonitor.Functions/Functions/Config/GetAllTenantConfigurationsFunction.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Functions/Config/GetAllTenantConfigurationsFunction.cs
@@ -1,8 +1,12 @@
 using System;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using System.Web;
 using AutopilotMonitor.Functions.Helpers;
+using AutopilotMonitor.Functions.Pagination;
 using AutopilotMonitor.Functions.Services;
+using AutopilotMonitor.Shared.Pagination;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
@@ -31,13 +35,80 @@ namespace AutopilotMonitor.Functions.Functions.Config
                 // Authentication + GlobalAdminOnly authorization enforced by PolicyEnforcementMiddleware
                 string userIdentifier = TenantHelper.GetUserIdentifier(req);
 
-                _logger.LogInformation($"GetAllTenantConfigurations by Global Admin {userIdentifier}");
+                var query = HttpUtility.ParseQueryString(req.Url.Query ?? string.Empty);
+                var parsed = TenantConfigPagination.ParseQuery(query);
+                if (parsed.Error != null)
+                {
+                    var bad = req.CreateResponse(HttpStatusCode.BadRequest);
+                    await bad.WriteAsJsonAsync(new { error = parsed.Error });
+                    return bad;
+                }
 
-                var configurations = await _configService.GetAllConfigurationsAsync();
+                // Legacy/default mode: no pageSize → unpaginated bare full-config array.
+                // Web consumers (tenant selectors + admin config editor) depend on this shape.
+                if (parsed.PageSize == null)
+                {
+                    _logger.LogInformation($"GetAllTenantConfigurations (full) by Global Admin {userIdentifier}");
+                    var configurations = await _configService.GetAllConfigurationsAsync();
 
-                var response = req.CreateResponse(HttpStatusCode.OK);
-                await response.WriteAsJsonAsync(configurations);
-                return response;
+                    var response = req.CreateResponse(HttpStatusCode.OK);
+                    await response.WriteAsJsonAsync(configurations);
+                    return response;
+                }
+
+                // Paginated mode: opt-in via ?pageSize=. Returns a secret-stripped projection
+                // so tenant secrets (webhook/SAS/branding URLs, allow-lists) never leave the
+                // backend. Consumed by the MCP list_tenants tool.
+                _logger.LogInformation($"GetAllTenantConfigurations (page, size {parsed.PageSize}) by Global Admin {userIdentifier}");
+
+                var callerTenantId = TenantHelper.GetTenantId(req);
+
+                string? azureToken = null;
+                if (parsed.Continuation != null)
+                {
+                    if (!TenantConfigPagination.TryAcceptContinuation(
+                            parsed.Continuation, callerTenantId, out azureToken, out var rejectReason))
+                    {
+                        _logger.LogWarning("GetAllTenantConfigurations: continuation rejected ({Reason})", rejectReason);
+                        var bad = req.CreateResponse(HttpStatusCode.BadRequest);
+                        await bad.WriteAsJsonAsync(new
+                        {
+                            error = $"Invalid continuation token ({rejectReason}). Restart pagination from the first page.",
+                        });
+                        return bad;
+                    }
+                }
+
+                var page = await _configService.GetConfigurationsPageAsync(parsed.PageSize.Value, azureToken);
+
+                // Keep-list projection — only non-sensitive identity / lifecycle / plan fields.
+                var tenants = page.Items.Select(c => new
+                {
+                    tenantId = c.TenantId,
+                    domainName = c.DomainName,
+                    planTier = c.PlanTier,
+                    disabled = c.Disabled,
+                    disabledReason = c.DisabledReason,
+                    onboardedAt = c.OnboardedAt,
+                    onboardedBy = c.OnboardedBy,
+                    lastUpdated = c.LastUpdated,
+                    dataRetentionDays = c.DataRetentionDays,
+                }).ToList();
+
+                string? nextLink = null;
+                if (!string.IsNullOrEmpty(page.NextRawToken))
+                {
+                    var fp = TenantConfigPagination.Fingerprint(callerTenantId);
+                    var wireToken = ContinuationToken.Encode(page.NextRawToken!, callerTenantId, fp);
+                    nextLink = TenantConfigPagination.BuildNextLink(parsed.PageSize.Value, wireToken);
+                }
+
+                return await req.OkAsync(new
+                {
+                    count = tenants.Count,
+                    tenants,
+                    nextLink,
+                });
             }
             catch (Exception ex)
             {

--- a/src/Backend/AutopilotMonitor.Functions/Pagination/TenantConfigPagination.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Pagination/TenantConfigPagination.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.Text;
+using AutopilotMonitor.Shared.Pagination;
+
+namespace AutopilotMonitor.Functions.Pagination
+{
+    /// <summary>
+    /// Pure helpers for the opt-in pagination surface on <c>GET /api/config/all</c>.
+    /// The endpoint is GlobalAdminOnly and has no filter parameters, so the
+    /// continuation token only binds the caller's identity (defends against
+    /// cross-caller token replay). When <c>pageSize</c> is absent the function
+    /// returns the legacy unpaginated bare array; these helpers only apply once
+    /// the caller opts into pagination.
+    /// </summary>
+    public static class TenantConfigPagination
+    {
+        public const int DefaultPageSize = 200;
+        public const int MaxPageSize = 1000;
+
+        public static string Fingerprint(string callerTenantId) =>
+            ContinuationToken.ComputeFingerprint(new[]
+            {
+                new KeyValuePair<string, string?>("scope", "config-all"),
+                new KeyValuePair<string, string?>("tenantId", callerTenantId),
+            });
+
+        public sealed class Parsed
+        {
+            /// <summary>Null when the caller did not opt into pagination (legacy bare-array mode).</summary>
+            public int? PageSize { get; init; }
+            public string? Continuation { get; init; }
+            public string? Error { get; init; }
+        }
+
+        public static Parsed ParseQuery(NameValueCollection? query)
+        {
+            var pageSizeRaw = query?["pageSize"];
+            var continuationRaw = query?["continuation"];
+
+            int? pageSize = null;
+            if (!string.IsNullOrEmpty(pageSizeRaw))
+            {
+                if (!int.TryParse(pageSizeRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n))
+                    return new Parsed { Error = "pageSize must be an integer" };
+                if (n < 1 || n > MaxPageSize)
+                    return new Parsed { Error = $"pageSize must be between 1 and {MaxPageSize}" };
+                pageSize = n;
+            }
+
+            // continuation is meaningless without pageSize — silently drop.
+            var continuation = pageSize.HasValue && !string.IsNullOrEmpty(continuationRaw)
+                ? continuationRaw
+                : null;
+
+            return new Parsed { PageSize = pageSize, Continuation = continuation };
+        }
+
+        public static bool TryAcceptContinuation(
+            string raw,
+            string callerTenantId,
+            out string azureToken,
+            out string? rejectReason)
+        {
+            var fp = Fingerprint(callerTenantId);
+            return ContinuationToken.TryDecode(raw, callerTenantId, fp, out azureToken, out rejectReason);
+        }
+
+        public static string BuildNextLink(int pageSize, string wireContinuation)
+        {
+            var sb = new StringBuilder("/api/config/all");
+            sb.Append('?');
+            sb.Append("pageSize=").Append(pageSize.ToString(CultureInfo.InvariantCulture));
+            sb.Append("&continuation=").Append(System.Uri.EscapeDataString(wireContinuation));
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions/Services/TenantConfigurationService.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/TenantConfigurationService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutopilotMonitor.Shared.DataAccess;
 using AutopilotMonitor.Shared.Models;
+using AutopilotMonitor.Shared.Pagination;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
@@ -165,6 +166,24 @@ namespace AutopilotMonitor.Functions.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error loading all tenant configurations");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Gets one page of tenant configurations (for Global Admin use), ordered by TenantId.
+        /// Unlike <see cref="GetAllConfigurationsAsync"/> this does not load every tenant at once;
+        /// callers follow the page's continuation token until it is null.
+        /// </summary>
+        public async Task<RawPage<TenantConfiguration>> GetConfigurationsPageAsync(int pageSize, string? continuation)
+        {
+            try
+            {
+                return await _configRepo.GetTenantConfigurationsPageAsync(pageSize, continuation);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error loading tenant configurations page");
                 throw;
             }
         }

--- a/src/McpServer/autopilot-monitor-mcp/src/__tests__/security-guards.test.ts
+++ b/src/McpServer/autopilot-monitor-mcp/src/__tests__/security-guards.test.ts
@@ -18,7 +18,7 @@ import { followNextLink } from '../client.js';
 import { SessionIdSchema } from '../tools/shared.js';
 import { ApiError } from '../client.js';
 import { toolError } from '../tools/error-handler.js';
-import { extractTenantList, TENANT_SAFE_FIELDS } from '../tools/admin.js';
+import { extractTenantList, TENANT_SAFE_FIELDS, projectTenantFields } from '../tools/admin.js';
 
 // Importing the OAuth helper requires the env var that gates module load.
 // Set a dummy value before the import resolves so the throw doesn't fire.
@@ -478,5 +478,32 @@ describe('list_tenants — extractTenantList keep-list projection', () => {
     expect(result).toHaveLength(4);
     expect(result[0]).toEqual({});
     expect(result[3].tenantId).toBe('contoso-tenant-id');
+  });
+});
+
+describe('list_tenants — projectTenantFields client-side field trim', () => {
+  const tenants: Record<string, unknown>[] = [
+    { tenantId: 'aaa', domainName: 'alpha.example.com', planTier: 'pro', disabled: true },
+    { tenantId: 'bbb', domainName: 'beta.onmicrosoft.com', planTier: 'free', disabled: false },
+  ];
+
+  it('returns rows unchanged when no fields are given', () => {
+    expect(projectTenantFields(tenants, undefined)).toEqual(tenants);
+    expect(projectTenantFields(tenants, '')).toEqual(tenants);
+  });
+
+  it('keeps only the requested fields', () => {
+    const out = projectTenantFields(tenants, 'domainName');
+    for (const t of out) expect(Object.keys(t).sort()).toEqual(['domainName', 'tenantId']);
+  });
+
+  it('always retains tenantId even when not requested', () => {
+    const out = projectTenantFields(tenants, 'planTier');
+    expect(Object.keys(out[0]).sort()).toEqual(['planTier', 'tenantId']);
+  });
+
+  it('tolerates whitespace and empty entries in the fields list', () => {
+    const out = projectTenantFields(tenants, ' domainName , , planTier ');
+    expect(Object.keys(out[0]).sort()).toEqual(['domainName', 'planTier', 'tenantId']);
   });
 });

--- a/src/McpServer/autopilot-monitor-mcp/src/tools/admin.ts
+++ b/src/McpServer/autopilot-monitor-mcp/src/tools/admin.ts
@@ -40,6 +40,27 @@ export function extractTenantList(data: unknown): Record<string, unknown>[] {
   });
 }
 
+/**
+ * Keep only a comma-separated subset of fields from already-safe tenant rows.
+ * `tenantId` is always retained — the tool's whole purpose is discovering tenant
+ * IDs for other tools. Pagination-independent (operates on whatever page came
+ * back), so it never interacts with the backend cursor.
+ */
+export function projectTenantFields(
+  rows: Record<string, unknown>[],
+  fields: string | undefined,
+): Record<string, unknown>[] {
+  if (!fields) return rows;
+  const keep = new Set(
+    fields.split(',').map((f) => f.trim()).filter(Boolean).concat(['tenantId']),
+  );
+  return rows.map((row) => {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(row)) if (keep.has(key)) out[key] = row[key];
+    return out;
+  });
+}
+
 export function registerAdminTools(server: McpServer): void {
   // Tool 11: get_api_usage
   server.tool(
@@ -249,16 +270,36 @@ export function registerAdminTools(server: McpServer): void {
   // them down to TENANT_SAFE_FIELDS before anything reaches the model.
   server.tool(
     'list_tenants',
-    'List all onboarded tenants with their identity, plan tier, and lifecycle status (onboarded/disabled dates). ' +
+    'List onboarded tenants with their identity, plan tier, and lifecycle status (onboarded/disabled dates). ' +
     'Global Admin only. Use this to discover tenant IDs for the tenantId parameter of other tools when running ' +
-    'cross-tenant investigations. Returns only non-sensitive fields — secrets (webhook URLs, SAS URLs) are stripped.',
-    {},
+    'cross-tenant investigations. Returns only non-sensitive fields — secrets (webhook URLs, SAS URLs) are stripped ' +
+    'server-side. Tenants are sorted by tenantId and returned in pages (default 100). For lean ID discovery pass ' +
+    '`fields=tenantId,domainName`. ' +
+    'Pagination: when "nextLink" is present, more tenants are available — call again and pass that whole string ' +
+    'back as "continuation". Stop when nextLink is absent.',
+    {
+      fields: z.string().optional()
+        .describe('Comma-separated subset of safe fields to return (e.g. "tenantId,domainName" for lean ID discovery). ' +
+                  'tenantId is always included. Default: all safe fields. Trims the returned page client-side.'),
+      pageSize: z.coerce.number().int().min(1).max(1000).optional().default(100)
+        .describe('Page size (1-1000, default 100). Tenants are sorted by tenantId; follow nextLink to fetch more.'),
+      continuation: z.string().optional()
+        .describe('Either the opaque "continuation" value from a prior response or the full nextLink path — both are accepted; the latter is preferred so backend-echoed query params round-trip correctly.'),
+    },
     READ_ONLY,
     async (args) => withToolTelemetry('list_tenants', async () => {
       try {
-        const data = await apiFetch('/api/config/all');
-        const tenants = extractTenantList(data);
-        return toolResultText({ count: tenants.length, tenants }, MAX_RESULT_SIZE_CHARS.small);
+        const { fields, pageSize, continuation } = args;
+        // /api/config/all supports opt-in pagination: passing pageSize switches the
+        // backend from its legacy unpaginated bare array to a secret-stripped
+        // { count, tenants, nextLink } envelope. extractTenantList re-applies the
+        // keep-list as defense-in-depth; projectTenantFields honours an optional fields= trim.
+        const path = followNextLink('/api/config/all', { pageSize }, continuation);
+        const data = await apiFetch(path) as { count?: number; tenants?: unknown[]; nextLink?: string | null };
+        const tenants = projectTenantFields(extractTenantList({ tenants: data?.tenants ?? [] }), fields);
+        return toolResultText(
+          { count: tenants.length, tenants, nextLink: data?.nextLink ?? null },
+          MAX_RESULT_SIZE_CHARS.adminStream);
       } catch (error: unknown) {
         return toolError('list_tenants', args, error);
       }

--- a/src/Shared/AutopilotMonitor.Shared/DataAccess/IConfigRepository.cs
+++ b/src/Shared/AutopilotMonitor.Shared/DataAccess/IConfigRepository.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutopilotMonitor.Shared.Models;
+using AutopilotMonitor.Shared.Pagination;
 
 namespace AutopilotMonitor.Shared.DataAccess
 {
@@ -15,6 +16,13 @@ namespace AutopilotMonitor.Shared.DataAccess
         Task<TenantConfiguration?> GetTenantConfigurationAsync(string tenantId);
         Task<bool> SaveTenantConfigurationAsync(TenantConfiguration config);
         Task<List<TenantConfiguration>> GetAllTenantConfigurationsAsync();
+
+        /// <summary>
+        /// One page of tenant configurations, ordered by TenantId (Azure cross-partition
+        /// scan over RowKey eq 'config' is PartitionKey-ascending and PartitionKey == TenantId).
+        /// Carries the store's opaque continuation token for the function layer to wrap.
+        /// </summary>
+        Task<RawPage<TenantConfiguration>> GetTenantConfigurationsPageAsync(int pageSize, string? continuation);
 
         // --- Admin Configuration ---
         Task<AdminConfiguration?> GetAdminConfigurationAsync();


### PR DESCRIPTION
…s size-cap

The MCP list_tenants tool fetched GET /api/config/all, which returns all tenant configs in one unpaginated array. With ~198 tenants the projected response exceeded the tool response cap and was offloaded to a file, making the tool unusable for the model.

Add backward-compatible opt-in pagination to config/all (same dual-mode pattern as GetSessionReportsFunction):
- No pageSize  -> unchanged legacy bare full-config array (web + maintenance aggregation depend on this shape; zero regression).
- pageSize     -> secret-stripped { count, tenants, nextLink } envelope using
  the existing ContinuationToken HMAC (scope "config-all", caller-bound),
  TenantId-ordered pages. Secrets never leave the backend.

Backend: GetTenantConfigurationsPageAsync (repo + service), TenantConfigPagination helper, dual-mode GetAllTenantConfigurationsFunction. Route/policy unchanged. MCP: list_tenants now follows nextLink against config/all (extractTenantList as defense-in-depth + optional fields= trim); client-side selectTenantPage removed.

Tests: TenantConfigPaginationTests 13/13; MCP security-guards 56/56. No /api/global/ relocation here - that convention cleanup is deferred.