### PR TITLE
fix(agent-v2): remediate all 28 findings from the 2026-07-02 V2 delta review

### DIFF
--- a/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Monitoring/Analyzers/ConsolePrefetchScannerTests.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Monitoring/Analyzers/ConsolePrefetchScannerTests.cs
@@ -114,6 +114,42 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Monitoring.Analyzers
         }
 
         [Fact]
+        public void Artifact_within_clock_skew_tolerance_before_boot_is_still_flagged()
+        {
+            // M5: an NTP correction between the .pf write and the scan can push the derived boot
+            // time past a REAL console's artifact timestamp. Within the tolerance the artifact
+            // must still count as after-boot.
+            using var rig = new Rig();
+            rig.WritePf("CMD.EXE-0BD30981.pf", BootUtc.AddMinutes(-5)); // inside the 10-min tolerance
+
+            rig.NewScanner().AnalyzeAtStartup();
+
+            Assert.NotNull(rig.PrefetchEvent());
+        }
+
+        [Fact]
+        public void Gate_suppresses_even_when_installer_cmd_refreshed_the_artifact()
+        {
+            // M6: ESP `cmd /c` installer wrappers refresh CMD.EXE-*.pf between reboots. The
+            // scanner cannot attribute the newer timestamp to a human console, so the Warning is
+            // once-per-enrollment — a refreshed artifact must NOT re-emit on the next restart.
+            using var rig = new Rig();
+            rig.WritePf("CMD.EXE-0BD30981.pf", BootUtc.AddMinutes(4));
+            var gate = rig.NewGate();
+
+            rig.NewScanner(gate: gate).AnalyzeAtStartup();
+
+            rig.WritePf("CMD.EXE-0BD30981.pf", BootUtc.AddMinutes(45)); // installer churn
+            rig.NewScanner(gate: gate).AnalyzeAtStartup();
+
+            var emitted = rig.Sink.Posted.Count(p =>
+                p.Payload != null
+                && p.Payload.TryGetValue(SignalPayloadKeys.EventType, out var et)
+                && et == "console_prefetch_detected");
+            Assert.Equal(1, emitted);
+        }
+
+        [Fact]
         public void No_cmd_artifact_stays_silent()
         {
             using var rig = new Rig();

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Monitoring/Ime/ImeLogTrackerScriptStatePersistenceTests.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Monitoring/Ime/ImeLogTrackerScriptStatePersistenceTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using AutopilotMonitor.Agent.V2.Core.Logging;
+using AutopilotMonitor.Agent.V2.Core.Monitoring.Enrollment.Ime;
+using AutopilotMonitor.Agent.V2.Core.Tests.Harness;
+using AutopilotMonitor.Shared.Models;
+using Xunit;
+
+namespace AutopilotMonitor.Agent.V2.Core.Tests.Monitoring.Ime
+{
+    /// <summary>
+    /// H1 (delta review 2026-07-02): the platform-script emission markers and pending buffer must
+    /// survive an agent restart. Field scenario: the shutdown pass force-flushes a fallback
+    /// completion, the agent restarts (stall restarts run up to ~88× per session), IME writes its
+    /// authoritative PS-SCRIPT-RESULT line after the flush — the restarted tracker parses that
+    /// line fresh (it lies beyond the persisted file position) and, without the persisted marker,
+    /// emitted a duplicate script_completed. Also covers the stale-result guard (L1) and the
+    /// restart-safe script_timeout_suspected claim (L10).
+    /// </summary>
+    public sealed class ImeLogTrackerScriptStatePersistenceTests
+    {
+        private static ImeLogTracker BuildTracker(TempDirectory tmp, out List<ScriptExecutionState> emitted)
+        {
+            var captured = new List<ScriptExecutionState>();
+            emitted = captured;
+            var tracker = new ImeLogTracker(
+                logFolder: tmp.Path,
+                patterns: new List<ImeLogPattern>(),
+                logger: new AgentLogger(tmp.Path, AgentLogLevel.Info),
+                stateDirectory: tmp.Path);
+            tracker.OnScriptCompleted = s => captured.Add(s);
+            return tracker;
+        }
+
+        [Fact]
+        public void Fallback_marker_survives_restart_and_dedupes_late_ime_result()
+        {
+            using var tmp = new TempDirectory();
+            var observedAt = new DateTime(2026, 7, 3, 9, 0, 0, DateTimeKind.Utc);
+
+            // Run 1: exit code seen, shutdown force-flush emits the fallback completion.
+            var tracker1 = BuildTracker(tmp, out var emitted1);
+            tracker1.SeedPendingPlatformScriptForTesting("policyA", exitCode: 0, exitObservedAtUtc: observedAt);
+            tracker1.FlushStalePlatformScriptResults(observedAt.AddSeconds(1), force: true);
+            Assert.Single(emitted1);
+            tracker1.SaveStateForTest();
+
+            // Restart: IME's PS-SCRIPT-RESULT line for the SAME execution arrives now.
+            var tracker2 = BuildTracker(tmp, out var emitted2);
+            tracker2.LoadStateForTest();
+            tracker2.CompletePlatformScriptFromImeResultForTesting("policyA", "Success");
+
+            Assert.Empty(emitted2); // was a duplicate before the fix
+        }
+
+        [Fact]
+        public void Pending_script_survives_restart_and_flushes_after_grace()
+        {
+            using var tmp = new TempDirectory();
+            var observedAt = new DateTime(2026, 7, 3, 9, 0, 0, DateTimeKind.Utc);
+
+            // Exit code observed but neither flushed nor resolved before the agent died.
+            var tracker1 = BuildTracker(tmp, out var emitted1);
+            tracker1.SeedPendingPlatformScriptForTesting("policyB", exitCode: 3, exitObservedAtUtc: observedAt);
+            tracker1.SaveStateForTest();
+            Assert.Empty(emitted1);
+
+            // Restarted tracker continues the grace window instead of dropping the script.
+            var tracker2 = BuildTracker(tmp, out var emitted2);
+            tracker2.LoadStateForTest();
+            tracker2.FlushStalePlatformScriptResults(observedAt.AddSeconds(20));
+
+            var script = Assert.Single(emitted2);
+            Assert.Equal("policyB", script.PolicyId);
+            Assert.Equal("Failed", script.Result);
+            Assert.Equal("agentexecutor_fallback", script.ResultSource);
+        }
+
+        [Fact]
+        public void Fresh_start_after_restart_still_clears_restored_marker()
+        {
+            using var tmp = new TempDirectory();
+            var observedAt = new DateTime(2026, 7, 3, 9, 0, 0, DateTimeKind.Utc);
+
+            var tracker1 = BuildTracker(tmp, out _);
+            tracker1.SeedPendingPlatformScriptForTesting("policyC", exitCode: 0, exitObservedAtUtc: observedAt);
+            tracker1.FlushStalePlatformScriptResults(observedAt.AddSeconds(1), force: true);
+            tracker1.SaveStateForTest();
+
+            // Restart, then a genuine RE-RUN of the same policy (fresh start clears the marker).
+            var tracker2 = BuildTracker(tmp, out var emitted2);
+            tracker2.LoadStateForTest();
+            tracker2.SeedPendingPlatformScriptForTesting("policyC", exitCode: 0, exitObservedAtUtc: observedAt.AddMinutes(10));
+            tracker2.CompletePlatformScriptFromImeResultForTesting("policyC", "Success", observedAt.AddMinutes(11));
+
+            var script = Assert.Single(emitted2);
+            Assert.Equal("ime_policy_result", script.ResultSource);
+        }
+
+        [Fact]
+        public void Old_state_file_without_script_fields_loads_clean()
+        {
+            using var tmp = new TempDirectory();
+
+            // Persist a state file from "before the fix" (fields null).
+            var persistence = new ImeTrackerStatePersistence(tmp.Path, new AgentLogger(tmp.Path, AgentLogLevel.Info));
+            persistence.Save(new ImeTrackerStateData { CurrentPhaseOrder = 2 });
+
+            var tracker = BuildTracker(tmp, out var emitted);
+            tracker.LoadStateForTest(); // must not throw
+
+            // Degrades to pre-fix behavior: no markers restored, normal emission works.
+            tracker.CompletePlatformScriptFromImeResultForTesting("policyD", "Success");
+            Assert.Single(emitted);
+        }
+
+        [Fact]
+        public void Stale_result_older_than_current_run_start_is_dropped()
+        {
+            using var tmp = new TempDirectory();
+            var run2Start = new DateTime(2026, 7, 3, 10, 0, 0, DateTimeKind.Utc);
+
+            var tracker = BuildTracker(tmp, out var emitted);
+            // Run 2 is live (fresh slot with its start stamped)…
+            tracker.SeedPendingPlatformScriptForTesting("policyE", exitCode: null, exitObservedAtUtc: null, startedAtUtc: run2Start);
+
+            // …when run 1's late PS-SCRIPT-RESULT (older than run 2's start) finally arrives.
+            tracker.CompletePlatformScriptFromImeResultForTesting("policyE", "Failed", run2Start.AddMinutes(-5));
+            Assert.Empty(emitted);
+
+            // Run 2's own result (newer than its start) still emits normally.
+            tracker.CompletePlatformScriptFromImeResultForTesting("policyE", "Success", run2Start.AddMinutes(2));
+            var script = Assert.Single(emitted);
+            Assert.Equal("Success", script.Result);
+            Assert.Equal(run2Start, script.StartedAtUtc);
+        }
+
+        [Fact]
+        public void Script_timeout_claim_is_one_shot_and_survives_restart()
+        {
+            using var tmp = new TempDirectory();
+
+            var tracker1 = BuildTracker(tmp, out _);
+            Assert.True(tracker1.TryClaimScriptTimeoutSuspected("policyF"));
+            Assert.False(tracker1.TryClaimScriptTimeoutSuspected("policyF")); // in-lifetime dedup
+            tracker1.SaveStateForTest();
+
+            var tracker2 = BuildTracker(tmp, out _);
+            tracker2.LoadStateForTest();
+            Assert.False(tracker2.TryClaimScriptTimeoutSuspected("policyF")); // cross-restart dedup
+            Assert.True(tracker2.TryClaimScriptTimeoutSuspected("policyG"));  // other policies unaffected
+        }
+    }
+}

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Monitoring/Security/ConsoleBypassWatcherTests.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Monitoring/Security/ConsoleBypassWatcherTests.cs
@@ -73,12 +73,25 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Monitoring.Security
         [Theory]
         [InlineData(@"C:\WINDOWS\system32\cmd.exe /c ""install.bat""")]
         [InlineData(@"cmd.exe /C ping")]
-        [InlineData(@"cmd.exe /k doskey")]
         public void Scripted_cmd_is_ignored(string commandLine)
         {
             using var rig = new Rig(Probe(commandLine));
             rig.Sut.HandleStart(2222, 1, sessionId: 1, ownerSidHint: null, detectedVia: "process_start_trace");
             Assert.Empty(rig.Detected);
+        }
+
+        [Fact]
+        public void Run_and_stay_cmd_k_raises_low_confidence()
+        {
+            // L12: /k runs its command and then leaves a fully interactive shell — a deliberate
+            // false-negative seam if ignored (e.g. a technician-planted `cmd /k whoami`).
+            using var rig = new Rig(Probe(@"cmd.exe /k whoami"));
+
+            rig.Sut.HandleStart(2222, 1, sessionId: 1, ownerSidHint: null, detectedVia: "process_start_trace");
+
+            var info = Assert.Single(rig.Detected);
+            Assert.Equal("low", info.Confidence);
+            Assert.Equal("interactive_console_with_command", info.Classification);
         }
 
         [Fact]
@@ -126,11 +139,13 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Monitoring.Security
         // ---------------------------------------------------------------- Classify (pure)
 
         [Theory]
-        [InlineData(0, BareCmd, "Ignore")]                          // service session
-        [InlineData(1, null, "UnclassifiedInteractive")]            // instant-close
-        [InlineData(1, BareCmd, "InteractiveConsole")]              // bare shell
-        [InlineData(1, @"cmd.exe /c foo", "Ignore")]                // scripted
-        [InlineData(2, @"C:\x\cmd.exe /K bar", "Ignore")]           // scripted, other session
+        [InlineData(0, BareCmd, "Ignore")]                             // service session
+        [InlineData(1, null, "UnclassifiedInteractive")]               // instant-close
+        [InlineData(1, BareCmd, "InteractiveConsole")]                 // bare shell
+        [InlineData(1, @"cmd.exe /c foo", "Ignore")]                   // scripted, run-and-exit
+        [InlineData(2, @"C:\x\cmd.exe /K bar", "InteractiveWithCommand")] // L12: /k stays interactive
+        [InlineData(1, @"cmd.exe /k whoami", "InteractiveWithCommand")]   // technician-planted shell
+        [InlineData(1, @"cmd.exe /d/q/c exit 9", "Ignore")]            // combined run-and-exit wins
         public void Classify_maps_session_and_commandline(int sessionId, string? commandLine, string expected)
         {
             Assert.Equal(expected, ConsoleBypassWatcher.Classify(sessionId, commandLine).ToString());
@@ -147,9 +162,9 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Monitoring.Security
         [InlineData("", false)]
         [InlineData(@"cmd.exe /c whoami", true)]
         [InlineData(@"cmd.exe /C whoami", true)]
-        [InlineData(@"cmd.exe /k", true)]
+        [InlineData(@"cmd.exe /k", false)]                       // L12: /k leaves an interactive shell
         [InlineData(@"cmd.exe /d/q/c exit 9", true)]             // combined switches — the field case
-        [InlineData(@"cmd.exe /D/Q/K stay", true)]
+        [InlineData(@"cmd.exe /D/Q/K stay", false)]              // L12: run-and-stay is not scripted
         [InlineData(@"""C:\WINDOWS\system32\cmd.exe"" /c ""x.bat""", true)]
         public void HasScriptArgument_detects_run_command_switch(string commandLine, bool expected)
         {

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Orchestration/DecisionStepProcessorParkedTripwireTests.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Orchestration/DecisionStepProcessorParkedTripwireTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using AutopilotMonitor.Agent.V2.Core.Logging;
 using AutopilotMonitor.Agent.V2.Core.Orchestration;
 using AutopilotMonitor.Agent.V2.Core.Tests.Harness;
@@ -18,10 +19,22 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Orchestration
     /// itself via a one-shot <c>session_parked_without_deadline</c> Warning. The parked states
     /// here are built artificially via the builder — production arming sites now prevent them,
     /// which is exactly why the tripwire exists (it catches the unknown variant 4).
+    /// <para>
+    /// M1 (delta review 2026-07-02): the tripwire is dwell-based — a parked step only ARMS a
+    /// timer; the Warning fires (and consumes the one-shot) only if the session is still parked
+    /// when the dwell elapses. A healthy transient park (HelloResolved → AwaitingDesktop,
+    /// desktop arrives seconds later) must neither fire nor burn the one-shot.
+    /// </para>
     /// </summary>
+    [Collection("SerialThreading")] // timer-driven assertions — serialise against other timing-sensitive suites
     public sealed class DecisionStepProcessorParkedTripwireTests : IDisposable
     {
         private static DateTime At => new DateTime(2026, 6, 12, 10, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>Short dwell so fire-path tests complete quickly; suppression tests wait ≥10× this.</summary>
+        private static readonly TimeSpan TestDwell = TimeSpan.FromMilliseconds(25);
+        private static readonly TimeSpan FireWait = TimeSpan.FromSeconds(5);
+        private static readonly TimeSpan SuppressWait = TimeSpan.FromMilliseconds(400);
 
         private readonly TempDirectory _tmp = new TempDirectory();
         private readonly AgentLogger _logger;
@@ -31,23 +44,29 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Orchestration
         private readonly FakeQuarantineSink _quarantine = new FakeQuarantineSink();
         private readonly FakeSignalIngressSink _sink = new FakeSignalIngressSink();
         private readonly DecisionEngine _engine = new DecisionEngine();
+        private DecisionStepProcessor _sut;
 
         public DecisionStepProcessorParkedTripwireTests()
         {
             _logger = new AgentLogger(_tmp.Path, AgentLogLevel.Info);
         }
 
-        public void Dispose() => _tmp.Dispose();
+        public void Dispose()
+        {
+            _sut?.Dispose();
+            _tmp.Dispose();
+        }
 
-        private DecisionStepProcessor Build(DecisionState initialState) =>
-            new DecisionStepProcessor(
+        private DecisionStepProcessor Build(DecisionState initialState, TimeSpan? dwell = null) =>
+            _sut = new DecisionStepProcessor(
                 initialState: initialState,
                 journal: _journal,
                 effectRunner: _effects,
                 snapshot: _snapshot,
                 quarantineSink: _quarantine,
                 logger: _logger,
-                informationalEvents: new InformationalEventPost(_sink, new FixedClock(At), _logger));
+                informationalEvents: new InformationalEventPost(_sink, new FixedClock(At), _logger),
+                parkedTripwireDwell: dwell ?? TestDwell);
 
         /// <summary>
         /// Baseline parked shape: AccountSetup entered, ESP exited finally AFTER that entry,
@@ -88,7 +107,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Orchestration
             return (step, signal);
         }
 
-        private FakeSignalIngressSink.PostedSignal? FindTripwirePost()
+        private FakeSignalIngressSink.PostedSignal FindTripwirePost()
         {
             foreach (var posted in _sink.Posted)
             {
@@ -117,28 +136,67 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Orchestration
             return count;
         }
 
+        /// <summary>Blocks until at least one tripwire post landed (dwell elapsed) or times out.</summary>
+        private bool WaitForTripwire() =>
+            SpinWait.SpinUntil(() => CountTripwirePosts() >= 1, FireWait);
+
+        /// <summary>Proves absence: waits well past the dwell, then asserts no post arrived.</summary>
+        private void AssertNoTripwireAfterDwell()
+        {
+            Thread.Sleep(SuppressWait);
+            Assert.Equal(0, CountTripwirePosts());
+        }
+
         // ===================================================================== Fires
 
         [Fact]
-        public void Parked_state_fires_tripwire_exactly_once()
+        public void Parked_state_fires_tripwire_exactly_once_after_dwell()
         {
             var sut = Build(BuildParkedState());
 
             var (s1, sig1) = ReduceInformational(sut, 10);
             sut.ApplyStep(s1, sig1);
+
+            Assert.True(WaitForTripwire(), "tripwire did not fire within the wait budget");
+
+            // Further parked pass-throughs after the fire must not emit again (one-shot).
             var (s2, sig2) = ReduceInformational(sut, 11);
             sut.ApplyStep(s2, sig2);
-
+            Thread.Sleep(SuppressWait);
             Assert.Equal(1, CountTripwirePosts());
 
-            var post = FindTripwirePost()!;
+            var post = FindTripwirePost();
             Assert.Equal(DecisionSignalKind.InformationalEvent, post.Kind);
-            Assert.Equal(nameof(SessionStage.EspAccountSetup), post.Payload!["stage"]);
+            Assert.Equal(nameof(SessionStage.EspAccountSetup), post.Payload["stage"]);
             Assert.Equal("Warning", post.Payload[SignalPayloadKeys.Severity]);
             Assert.Equal("true", post.Payload[SignalPayloadKeys.ImmediateUpload]);
             Assert.Contains("esp_final_exit", post.Payload["signalsSeen"]);
             Assert.Contains("account_setup_entered", post.Payload["signalsSeen"]);
             Assert.Equal(string.Empty, post.Payload["armedDeadlines"]);
+            Assert.True(post.Payload.ContainsKey("dwellSeconds"));
+        }
+
+        [Fact]
+        public void Parked_passthrough_steps_do_not_rebase_the_dwell()
+        {
+            // A truly parked session still produces telemetry pass-throughs; if each of them
+            // re-based the dwell the tripwire would never fire exactly when it matters most.
+            var sut = Build(BuildParkedState(), dwell: TimeSpan.FromMilliseconds(150));
+
+            var (s1, sig1) = ReduceInformational(sut, 10);
+            sut.ApplyStep(s1, sig1);
+
+            // Keep feeding parked pass-throughs faster than the dwell.
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+            long ordinal = 11;
+            while (CountTripwirePosts() == 0 && DateTime.UtcNow < deadline)
+            {
+                var (s, sig) = ReduceInformational(sut, ordinal++);
+                sut.ApplyStep(s, sig);
+                Thread.Sleep(20);
+            }
+
+            Assert.Equal(1, CountTripwirePosts());
         }
 
         [Fact]
@@ -149,6 +207,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Orchestration
             var (step, signal) = ReduceInformational(sut, 10);
             sut.ApplyStep(step, signal);
 
+            Assert.True(WaitForTripwire());
             Assert.Equal(1, CountTripwirePosts());
         }
 
@@ -162,24 +221,67 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Orchestration
             var (step, signal) = ReduceInformational(sut, 10);
             sut.ApplyStep(step, signal);
 
-            Assert.Equal(1, CountTripwirePosts());
-            Assert.Equal(DeadlineNames.ClassifierTick, FindTripwirePost()!.Payload!["armedDeadlines"]);
+            Assert.True(WaitForTripwire());
+            Assert.Equal(DeadlineNames.ClassifierTick, FindTripwirePost().Payload["armedDeadlines"]);
         }
 
         [Fact]
         public void AwaitingDesktop_parked_fires_with_stage_in_data()
         {
             // Deliberate design decision (plan PR1): AwaitingDesktop has no deadline today, so a
-            // parked AwaitingDesktop session IS visible via the tripwire. The stage field keeps
-            // it distinguishable in the field; a dedicated DesktopSafety deadline is a possible
-            // later iteration — NOT part of PR1.
+            // parked AwaitingDesktop session IS visible via the tripwire — but only after the
+            // dwell, so the healthy Hello→Desktop window stays silent (see the dwell tests).
             var sut = Build(BuildParkedState(stage: SessionStage.AwaitingDesktop));
 
             var (step, signal) = ReduceInformational(sut, 10);
             sut.ApplyStep(step, signal);
 
+            Assert.True(WaitForTripwire());
+            Assert.Equal(nameof(SessionStage.AwaitingDesktop), FindTripwirePost().Payload["stage"]);
+        }
+
+        // ===================================================================== Dwell semantics
+
+        [Fact]
+        public void Transient_park_resolved_before_dwell_neither_fires_nor_burns_the_one_shot()
+        {
+            // The healthy Classic window: HelloResolved cancels HelloSafety → AwaitingDesktop
+            // with no deadline; DesktopArrived (here: a resolution deadline appearing) follows
+            // before the dwell elapses.
+            var sut = Build(BuildParkedState(stage: SessionStage.AwaitingDesktop), dwell: TimeSpan.FromMilliseconds(250));
+
+            var (s1, sig1) = ReduceInformational(sut, 10);
+            sut.ApplyStep(s1, sig1);
+
+            // Park resolves quickly: next step carries a resolution-capable deadline.
+            var resolvedState = BuildParkedState(
+                stage: SessionStage.AwaitingDesktop,
+                deadlines: Deadline(DeadlineNames.AdvisoryCompletion));
+            var (s2Template, sig2) = ReduceInformational(sut, 11);
+            sut.ApplyStep(new DecisionStep(resolvedState, s2Template.Transition, Array.Empty<DecisionEffect>()), sig2);
+
+            AssertNoTripwireAfterDwell(); // no false alarm
+
+            // A REAL park later in the same run must still be able to fire — the one-shot was
+            // not consumed by the transient window.
+            var parkedAgain = BuildParkedState(stage: SessionStage.AwaitingDesktop);
+            var (s3Template, sig3) = ReduceInformational(sut, 12);
+            sut.ApplyStep(new DecisionStep(parkedAgain, s3Template.Transition, Array.Empty<DecisionEffect>()), sig3);
+
+            Assert.True(WaitForTripwire(), "genuine park after a transient window must still fire");
             Assert.Equal(1, CountTripwirePosts());
-            Assert.Equal(nameof(SessionStage.AwaitingDesktop), FindTripwirePost()!.Payload!["stage"]);
+        }
+
+        [Fact]
+        public void Dispose_cancels_a_pending_dwell()
+        {
+            var sut = Build(BuildParkedState());
+
+            var (step, signal) = ReduceInformational(sut, 10);
+            sut.ApplyStep(step, signal);
+            sut.Dispose();
+
+            AssertNoTripwireAfterDwell();
         }
 
         // ===================================================================== Suppressed
@@ -192,7 +294,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Orchestration
             var (step, signal) = ReduceInformational(sut, 10);
             sut.ApplyStep(step, signal);
 
-            Assert.Equal(0, CountTripwirePosts());
+            AssertNoTripwireAfterDwell();
         }
 
         [Fact]
@@ -204,7 +306,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Orchestration
             var (step, signal) = ReduceInformational(sut, 10);
             sut.ApplyStep(step, signal);
 
-            Assert.Equal(0, CountTripwirePosts());
+            AssertNoTripwireAfterDwell();
         }
 
         [Fact]
@@ -215,7 +317,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Orchestration
             var (step, signal) = ReduceInformational(sut, 10);
             sut.ApplyStep(step, signal);
 
-            Assert.Equal(0, CountTripwirePosts());
+            AssertNoTripwireAfterDwell();
         }
 
         [Fact]
@@ -226,7 +328,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Orchestration
             var (step, signal) = ReduceInformational(sut, 10);
             sut.ApplyStep(step, signal);
 
-            Assert.Equal(0, CountTripwirePosts());
+            AssertNoTripwireAfterDwell();
         }
 
         [Fact]
@@ -238,7 +340,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Orchestration
             var (step, signal) = ReduceInformational(sut, 10);
             sut.ApplyStep(step, signal);
 
-            Assert.Equal(0, CountTripwirePosts());
+            AssertNoTripwireAfterDwell();
         }
 
         [Fact]
@@ -252,7 +354,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Orchestration
             var (step, signal) = ReduceInformational(sut, 10);
             sut.ApplyStep(step, signal);
 
-            Assert.Equal(0, CountTripwirePosts());
+            AssertNoTripwireAfterDwell();
         }
 
         [Fact]
@@ -269,24 +371,26 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Orchestration
             var (step, signal) = ReduceInformational(sut, 10);
             sut.ApplyStep(step, signal);
 
-            Assert.Equal(0, CountTripwirePosts());
+            AssertNoTripwireAfterDwell();
         }
 
         [Fact]
         public void Without_informational_post_wired_parked_state_is_tolerated()
         {
             // Legacy ctor shape (no InformationalEventPost) — the tripwire is simply disabled.
-            var sut = new DecisionStepProcessor(
+            var sut = _sut = new DecisionStepProcessor(
                 initialState: BuildParkedState(),
                 journal: _journal,
                 effectRunner: _effects,
                 snapshot: _snapshot,
                 quarantineSink: _quarantine,
-                logger: _logger);
+                logger: _logger,
+                parkedTripwireDwell: TestDwell);
 
             var (step, signal) = ReduceInformational(sut, 10);
             sut.ApplyStep(step, signal);
 
+            Thread.Sleep(SuppressWait);
             Assert.Empty(_sink.Posted);
         }
 

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Persistence/StartupEventGateTests.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Persistence/StartupEventGateTests.cs
@@ -33,18 +33,81 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Persistence
         }
 
         [Fact]
-        public void ShouldEmit_state_survives_an_agent_restart()
+        public void ShouldEmit_state_survives_an_agent_restart_once_committed()
         {
             using var tmp = new TempDirectory();
             var logger = NewLogger(tmp.Path);
 
             var firstRun = new StartupEventGate(tmp.Path, logger);
             Assert.True(firstRun.ShouldEmit("aad_join_status", "not-joined"));
+            firstRun.MarkEmitted("aad_join_status"); // event went out → commit
 
             // New instance over the same state directory = agent restarted after a reboot.
             var secondRun = new StartupEventGate(tmp.Path, logger);
             Assert.False(secondRun.ShouldEmit("aad_join_status", "not-joined")); // unchanged → suppressed
             Assert.True(secondRun.ShouldEmit("aad_join_status", "joined"));      // late join → emits
+        }
+
+        [Fact]
+        public void Uncommitted_claim_does_not_survive_a_restart()
+        {
+            // M4 (delta review 2026-07-02): a crash between ShouldEmit and the actual emission
+            // must NOT suppress the event for the rest of the enrollment — only MarkEmitted
+            // (called after the emission) persists the claim.
+            using var tmp = new TempDirectory();
+            var logger = NewLogger(tmp.Path);
+
+            var firstRun = new StartupEventGate(tmp.Path, logger);
+            Assert.True(firstRun.ShouldEmit("tpm_info", "fp-static"));
+            // process dies here — no MarkEmitted
+
+            var secondRun = new StartupEventGate(tmp.Path, logger);
+            Assert.True(secondRun.ShouldEmit("tpm_info", "fp-static")); // re-emits after the crash
+        }
+
+        [Fact]
+        public void MarkEmitted_commits_only_its_own_key()
+        {
+            // Two events claim; only A's emission goes out before the crash. B must re-emit.
+            using var tmp = new TempDirectory();
+            var logger = NewLogger(tmp.Path);
+
+            var firstRun = new StartupEventGate(tmp.Path, logger);
+            Assert.True(firstRun.ShouldEmit("event_a", "fp-a"));
+            Assert.True(firstRun.ShouldEmit("event_b", "fp-b"));
+            firstRun.MarkEmitted("event_a"); // only A emitted before the crash
+
+            var secondRun = new StartupEventGate(tmp.Path, logger);
+            Assert.False(secondRun.ShouldEmit("event_a", "fp-a"));
+            Assert.True(secondRun.ShouldEmit("event_b", "fp-b"));
+        }
+
+        [Fact]
+        public void MarkEmitted_without_prior_claim_is_a_noop()
+        {
+            using var tmp = new TempDirectory();
+            var gate = new StartupEventGate(tmp.Path, NewLogger(tmp.Path));
+
+            gate.MarkEmitted("gate_exempt_type"); // never claimed → must not throw or persist
+            Assert.True(gate.ShouldEmit("gate_exempt_type", "fp"));
+        }
+
+        [Fact]
+        public void HasFingerprint_peeks_without_claiming()
+        {
+            using var tmp = new TempDirectory();
+            var logger = NewLogger(tmp.Path);
+
+            var firstRun = new StartupEventGate(tmp.Path, logger);
+            Assert.False(firstRun.HasFingerprint("disk_space_low", "low"));
+            Assert.True(firstRun.ShouldEmit("disk_space_low", "low"));
+            firstRun.MarkEmitted("disk_space_low");
+
+            var secondRun = new StartupEventGate(tmp.Path, logger);
+            Assert.True(secondRun.HasFingerprint("disk_space_low", "low"));
+            Assert.False(secondRun.HasFingerprint("disk_space_low", "rearmed"));
+            // The peek made no claim: an actual state change still goes through normally.
+            Assert.True(secondRun.ShouldEmit("disk_space_low", "rearmed"));
         }
 
         [Fact]

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Telemetry/PerformanceCollectorDiskLowTests.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Telemetry/PerformanceCollectorDiskLowTests.cs
@@ -7,7 +7,8 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Telemetry
     /// MON-B10 — covers the state-change-only transition logic behind the one-shot
     /// <c>disk_space_low</c> warning. The warning must fire exactly once on crossing below 2 GB,
     /// stay silent while the drive remains low (no heartbeat), and only re-arm after free space
-    /// recovers past the 3 GB hysteresis mark.
+    /// recovers past the 3 GB hysteresis mark. The <c>rearmed</c> out-flag (M3) tells the caller
+    /// when to persist the re-arm so the latch survives agent restarts.
     /// </summary>
     public class PerformanceCollectorDiskLowTests
     {
@@ -15,24 +16,27 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Telemetry
         public void AboveThreshold_DoesNotWarn_AndStaysDisarmed()
         {
             bool warned = false;
-            Assert.False(PerformanceCollector.EvaluateDiskLowTransition(50.0, ref warned));
+            Assert.False(PerformanceCollector.EvaluateDiskLowTransition(50.0, ref warned, out var rearmed));
             Assert.False(warned);
+            Assert.False(rearmed); // was never latched → nothing to re-arm/persist
         }
 
         [Fact]
         public void CrossingBelowThreshold_WarnsOnce_AndLatches()
         {
             bool warned = false;
-            Assert.True(PerformanceCollector.EvaluateDiskLowTransition(1.9, ref warned));
+            Assert.True(PerformanceCollector.EvaluateDiskLowTransition(1.9, ref warned, out var rearmed));
             Assert.True(warned);
+            Assert.False(rearmed);
         }
 
         [Fact]
         public void StillLowAfterWarning_DoesNotReWarn()
         {
             bool warned = true; // already warned on a previous low read
-            Assert.False(PerformanceCollector.EvaluateDiskLowTransition(1.5, ref warned));
+            Assert.False(PerformanceCollector.EvaluateDiskLowTransition(1.5, ref warned, out var rearmed));
             Assert.True(warned);
+            Assert.False(rearmed);
         }
 
         [Fact]
@@ -41,16 +45,18 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Telemetry
             // Between 2 GB (threshold) and 3 GB (recovery): not low enough to re-warn,
             // not recovered enough to re-arm. Must remain latched and silent.
             bool warned = true;
-            Assert.False(PerformanceCollector.EvaluateDiskLowTransition(2.5, ref warned));
+            Assert.False(PerformanceCollector.EvaluateDiskLowTransition(2.5, ref warned, out var rearmed));
             Assert.True(warned);
+            Assert.False(rearmed);
         }
 
         [Fact]
         public void RecoveryPastHysteresisMark_ReArms()
         {
             bool warned = true;
-            Assert.False(PerformanceCollector.EvaluateDiskLowTransition(3.0, ref warned));
+            Assert.False(PerformanceCollector.EvaluateDiskLowTransition(3.0, ref warned, out var rearmed));
             Assert.False(warned);
+            Assert.True(rearmed); // caller persists this transition (M3)
         }
 
         [Fact]
@@ -59,15 +65,16 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Telemetry
             bool warned = false;
 
             // First drop → warns and latches.
-            Assert.True(PerformanceCollector.EvaluateDiskLowTransition(1.0, ref warned));
+            Assert.True(PerformanceCollector.EvaluateDiskLowTransition(1.0, ref warned, out _));
             Assert.True(warned);
 
             // Recovers past the hysteresis mark → re-arms.
-            Assert.False(PerformanceCollector.EvaluateDiskLowTransition(4.0, ref warned));
+            Assert.False(PerformanceCollector.EvaluateDiskLowTransition(4.0, ref warned, out var rearmed));
             Assert.False(warned);
+            Assert.True(rearmed);
 
             // Drops again → warns a second time.
-            Assert.True(PerformanceCollector.EvaluateDiskLowTransition(1.8, ref warned));
+            Assert.True(PerformanceCollector.EvaluateDiskLowTransition(1.8, ref warned, out _));
             Assert.True(warned);
         }
 
@@ -76,8 +83,18 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Telemetry
         {
             // 2.0 GB is the boundary; the predicate is strict "below", so it must not warn.
             bool warned = false;
-            Assert.False(PerformanceCollector.EvaluateDiskLowTransition(2.0, ref warned));
+            Assert.False(PerformanceCollector.EvaluateDiskLowTransition(2.0, ref warned, out var rearmed));
             Assert.False(warned);
+            Assert.False(rearmed);
+        }
+
+        [Fact]
+        public void AboveRecovery_WithoutPriorWarning_DoesNotReportRearm()
+        {
+            // A healthy disk must not spam the persisted gate state on every sample.
+            bool warned = false;
+            Assert.False(PerformanceCollector.EvaluateDiskLowTransition(10.0, ref warned, out var rearmed));
+            Assert.False(rearmed);
         }
     }
 }

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Termination/EnrollmentTerminationHandlerTests.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core.Tests/Termination/EnrollmentTerminationHandlerTests.cs
@@ -230,7 +230,13 @@ namespace AutopilotMonitor.Agent.V2.Core.Tests.Termination
 
             public IReadOnlyList<AppPackageState>? GetStarvedUserEspApps() => _rig.StarvedAppsOverride;
 
-            public IReadOnlyCollection<string> StarvedUserEspAppsAlreadyReported => _rig.StarvedAlreadyReportedOverride;
+            // L6 — claim-based dedup: pre-seeded ids model apps the live path already reported.
+            private HashSet<string>? _starvedClaims;
+            public bool TryClaimStarvedUserEspAppReport(string appId)
+            {
+                _starvedClaims ??= new HashSet<string>(_rig.StarvedAlreadyReportedOverride, StringComparer.OrdinalIgnoreCase);
+                return _starvedClaims.Add(appId);
+            }
         }
 
         /// <summary>

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Enrollment/Ime/ImeLogTracker.Handlers.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Enrollment/Ime/ImeLogTracker.Handlers.cs
@@ -370,7 +370,24 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Enrollment.Ime
             }
 
             // Merge with pending AgentExecutor data if available
-            if (!_pendingPlatformScripts.TryGetValue(id, out var script))
+            if (_pendingPlatformScripts.TryGetValue(id, out var script))
+            {
+                // Stale-result guard: on an intra-lifetime re-run of the same policy, run 1's
+                // late PS-SCRIPT-RESULT can arrive after run 2's start line already created a
+                // fresh slot (the start clears the emitted-marker). Merging would pair run 2's
+                // StartedAtUtc/state with run 1's result and then drop run 2's genuine result at
+                // the marker check above. A result line always postdates its own run's start
+                // line in the source log, so a result older than the pending slot's start
+                // belongs to a previous run — drop it and keep the live slot intact.
+                if (script.StartedAtUtc.HasValue
+                    && LastMatchedLogTimestamp.HasValue
+                    && LastMatchedLogTimestamp.Value < script.StartedAtUtc.Value)
+                {
+                    _logger.Debug($"ImeLogTracker: platform script {id} result predates the current run's start — stale result from a previous run, skipping");
+                    return;
+                }
+            }
+            else
             {
                 script = new ScriptExecutionState
                 {
@@ -387,6 +404,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Enrollment.Ime
             EmitScriptEvent(script);
             _platformScriptResultEmitted.Add(id);
             _pendingPlatformScripts.Remove(id);
+            _stateDirty = true;
             if (string.Equals(_lastPlatformScriptPolicyId, id, StringComparison.OrdinalIgnoreCase))
                 _lastPlatformScriptPolicyId = null;
         }
@@ -464,6 +482,10 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Enrollment.Ime
 
             if (toRemove != null)
             {
+                // The flush can fire on a quiet polling cycle (grace expiry with no new log
+                // lines), where nothing else marks state dirty — the emitted-markers must reach
+                // the state file before a restart or the restarted tracker re-emits (H1).
+                _stateDirty = true;
                 foreach (var key in toRemove)
                 {
                     _pendingPlatformScripts.Remove(key);
@@ -475,7 +497,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Enrollment.Ime
 
         /// <summary>Test seam: inject a pending platform script as if AgentExecutor.log had reported
         /// its start + exit code, without an IME PS-SCRIPT-RESULT line.</summary>
-        internal void SeedPendingPlatformScriptForTesting(string policyId, int? exitCode, DateTime? exitObservedAtUtc, string stdout = null)
+        internal void SeedPendingPlatformScriptForTesting(string policyId, int? exitCode, DateTime? exitObservedAtUtc, string stdout = null, DateTime? startedAtUtc = null)
         {
             // Mirrors a fresh execution start: a new run clears any prior emitted-marker (see
             // HandleScriptStarted) so re-runs of the same policy within one lifetime emit again.
@@ -487,13 +509,16 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Enrollment.Ime
                 ExitCode = exitCode,
                 ExitObservedAtUtc = exitObservedAtUtc,
                 Stdout = stdout,
+                StartedAtUtc = startedAtUtc,
             };
             _lastPlatformScriptPolicyId = policyId;
         }
 
         /// <summary>Test seam: simulate the authoritative IME PS-SCRIPT-RESULT path for a platform
-        /// script (same code as <see cref="HandleScriptCompleted"/> minus regex extraction).</summary>
-        internal void CompletePlatformScriptFromImeResultForTesting(string policyId, string result)
+        /// script (same code as <see cref="HandleScriptCompleted"/> minus regex extraction).
+        /// <paramref name="resultLineTimestampUtc"/> stands in for the CMTrace timestamp of the
+        /// PS-SCRIPT-RESULT line (production reads it via <see cref="LastMatchedLogTimestamp"/>).</summary>
+        internal void CompletePlatformScriptFromImeResultForTesting(string policyId, string result, DateTime? resultLineTimestampUtc = null)
         {
             if (string.IsNullOrEmpty(policyId)) return;
 
@@ -505,8 +530,21 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Enrollment.Ime
                 return;
             }
 
-            if (!_pendingPlatformScripts.TryGetValue(policyId, out var script))
+            if (_pendingPlatformScripts.TryGetValue(policyId, out var script))
+            {
+                // Mirror of HandleScriptCompleted's stale-result guard: a result older than the
+                // pending slot's start belongs to a previous run of the same policy.
+                if (script.StartedAtUtc.HasValue
+                    && resultLineTimestampUtc.HasValue
+                    && resultLineTimestampUtc.Value < script.StartedAtUtc.Value)
+                {
+                    return;
+                }
+            }
+            else
+            {
                 script = new ScriptExecutionState { PolicyId = policyId, ScriptType = "platform" };
+            }
 
             script.Result = result;
             script.ResultSource = "ime_policy_result";
@@ -515,6 +553,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Enrollment.Ime
             _pendingPlatformScripts.Remove(policyId);
             if (string.Equals(_lastPlatformScriptPolicyId, policyId, StringComparison.OrdinalIgnoreCase))
                 _lastPlatformScriptPolicyId = null;
+            _stateDirty = true;
         }
 
         /// <summary>

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Enrollment/Ime/ImeLogTracker.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Enrollment/Ime/ImeLogTracker.cs
@@ -134,6 +134,27 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Enrollment.Ime
         private readonly Dictionary<string, DateTime> _healthScriptStartTimes =
             new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
 
+        // Restart-safe dedup for the adapter's one-shot script_timeout_suspected Warning.
+        // Owned by the tracker (not the adapter) solely so it rides the persisted state file —
+        // an in-memory set re-emits the Warning after every stall restart once the position
+        // bookmark is lost and the failing script's log tail is reprocessed.
+        private readonly HashSet<string> _scriptTimeoutSuspectedPosted =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Claims the one-shot <c>script_timeout_suspected</c> emission for a policy. Returns
+        /// false when a prior claim exists — including one restored from persisted state after
+        /// an agent restart, which is the whole point of routing the adapter's dedup through
+        /// the tracker.
+        /// </summary>
+        public bool TryClaimScriptTimeoutSuspected(string policyId)
+        {
+            if (string.IsNullOrEmpty(policyId)) return false;
+            if (!_scriptTimeoutSuspectedPosted.Add(policyId)) return false;
+            _stateDirty = true;
+            return true;
+        }
+
         private const int MaxScriptOutputLength = 2048;
         private const int MaxMultiLineBufferLines = 100;
 
@@ -631,6 +652,36 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Enrollment.Ime
                 }
             }
 
+            // H1 (delta review 2026-07-02): restore platform-script emission markers + pending
+            // buffer. Without these, the shutdown force-flush emits a fallback completion, the
+            // restarted tracker resumes past the persisted position, and IME's later-written
+            // PS-SCRIPT-RESULT line for the same execution emits a SECOND script_completed
+            // (the in-memory marker set started empty). Old state files have null here —
+            // degrades to the pre-fix behavior, no crash.
+            _platformScriptResultEmitted.Clear();
+            if (state.PlatformScriptResultEmitted != null)
+            {
+                foreach (var id in state.PlatformScriptResultEmitted)
+                    _platformScriptResultEmitted.Add(id);
+            }
+
+            _pendingPlatformScripts.Clear();
+            if (state.PendingPlatformScripts != null)
+            {
+                foreach (var pending in state.PendingPlatformScripts)
+                {
+                    if (!string.IsNullOrEmpty(pending?.PolicyId))
+                        _pendingPlatformScripts[pending.PolicyId] = pending;
+                }
+            }
+
+            _scriptTimeoutSuspectedPosted.Clear();
+            if (state.ScriptTimeoutSuspectedPosted != null)
+            {
+                foreach (var id in state.ScriptTimeoutSuspectedPosted)
+                    _scriptTimeoutSuspectedPosted.Add(id);
+            }
+
             // Re-activate patterns based on restored phase state
             ActivatePatterns(_logPhaseIsCurrentPhase, force: true);
 
@@ -669,6 +720,12 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Enrollment.Ime
                     kv => kv.Key,
                     kv => kv.Value.Select(ToPackageStateData).ToList(),
                     StringComparer.Ordinal),
+
+                // H1 (delta review 2026-07-02): platform-script dedup markers + pending buffer
+                // must survive restarts — see the LoadState comment for the duplicate scenario.
+                PlatformScriptResultEmitted = _platformScriptResultEmitted.ToList(),
+                PendingPlatformScripts = _pendingPlatformScripts.Values.ToList(),
+                ScriptTimeoutSuspectedPosted = _scriptTimeoutSuspectedPosted.ToList(),
             };
 
             // Store file positions by filename only (log folder is known)

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Enrollment/Ime/ImeTrackerStatePersistence.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Enrollment/Ime/ImeTrackerStatePersistence.cs
@@ -125,6 +125,19 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Enrollment.Ime
         // added — LoadState handles that as "no snapshots" and the in-memory dict stays empty
         // (degrades gracefully back to the live _packageStates view).
         public Dictionary<string, List<PackageStateData>> PhasePackageSnapshots { get; set; }
+
+        // H1 (delta review 2026-07-02): platform-script completion dedup must survive agent
+        // restarts. The shutdown pass force-flushes fallback completions from AgentExecutor exit
+        // codes; IME's authoritative PS-SCRIPT-RESULT line is often written AFTER that flush and
+        // lies beyond the persisted file position, so the restarted tracker parses it fresh —
+        // without the persisted marker set it would emit a duplicate script_completed. The
+        // pending buffer rides along so a script whose exit code was seen but not yet flushed
+        // continues its grace window after the restart instead of being silently dropped.
+        // ScriptExecutionState is a plain DTO, serialized directly (no mapping layer needed).
+        // All three are null on state files from before this fix — LoadState treats null as empty.
+        public List<string> PlatformScriptResultEmitted { get; set; }
+        public List<ScriptExecutionState> PendingPlatformScripts { get; set; }
+        public List<string> ScriptTimeoutSuspectedPosted { get; set; }
     }
 
     public class PackageStateData

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Enrollment/SystemSignals/DesktopArrivalDetector.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Enrollment/SystemSignals/DesktopArrivalDetector.cs
@@ -401,18 +401,27 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Enrollment.SystemSignals
         internal string ResolveOwner(int processId, int sessionId)
         {
             string owner = null;
+            var wtsErrored = false;
             try
             {
-                owner = (SessionOwnerResolver ?? ProcessOwnerLookup.ViaWts)(sessionId);
+                if (SessionOwnerResolver != null)
+                    owner = SessionOwnerResolver(sessionId);
+                else
+                    owner = ProcessOwnerLookup.ViaWts(sessionId, out wtsErrored);
             }
             catch (Exception ex)
             {
+                wtsErrored = true;
                 _logger.Debug($"DesktopArrivalDetector: WTS owner resolution threw for session {sessionId}: {ex.Message}");
             }
             if (!string.IsNullOrEmpty(owner))
                 return owner;
 
-            _wtsErrorCountSinceStart++;
+            // L15: count only real API failures. A session without a logged-on user yet is the
+            // normal OOBE polling case and must not inflate the liveness payloads' error rate
+            // (the WMI counter next door has failure-only semantics — keep them comparable).
+            if (wtsErrored)
+                _wtsErrorCountSinceStart++;
             return (ProcessOwnerResolver ?? GetProcessOwnerViaWmi)(processId);
         }
 

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Enrollment/SystemSignals/EspAndHelloTracker.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Enrollment/SystemSignals/EspAndHelloTracker.cs
@@ -250,6 +250,21 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Enrollment.SystemSignals
             }
         }
 
+        /// <summary>
+        /// L6 (delta review 2026-07-02): atomic test-and-add against the same dedupe set the
+        /// live (esp_exited) path uses. The termination sweep claims each app through this
+        /// instead of snapshotting <see cref="StarvedAppsReported"/> — a snapshot could race a
+        /// concurrent live emission between copy and emit and double-report the app.
+        /// </summary>
+        public bool TryClaimStarvedAppReport(string appId)
+        {
+            if (string.IsNullOrEmpty(appId)) return false;
+            lock (_starvedLock)
+            {
+                return _starvedAppsReported.Add(appId);
+            }
+        }
+
         // =====================================================================
         // Forwarded state/snapshot methods
         // =====================================================================

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Enrollment/SystemSignals/HelloTracker.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Enrollment/SystemSignals/HelloTracker.cs
@@ -1038,7 +1038,18 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Enrollment.SystemSignals
                     // Re-arm the existing one-shot wait timer for a single bounded grace window.
                     // The 10s-interval policy check timer keeps running and may flip the policy to
                     // enabled/disabled within this window; otherwise the next fire resolves it.
-                    _helloWaitTimer?.Change(TimeSpan.FromSeconds(_helloWaitTimeoutSeconds), TimeSpan.FromMilliseconds(-1));
+                    // L2 (delta review 2026-07-02): Stop() disposes the timers WITHOUT taking
+                    // _stateLock, so it can race this callback between the null-check and Change —
+                    // an unhandled ObjectDisposedException on a threadpool timer thread kills the
+                    // process on net48. Shutdown is winning anyway; swallow and bail.
+                    try
+                    {
+                        _helloWaitTimer?.Change(TimeSpan.FromSeconds(_helloWaitTimeoutSeconds), TimeSpan.FromMilliseconds(-1));
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        _logger.Debug("HelloTracker: wait-timer re-arm lost the race against Stop() — shutting down, grace window skipped");
+                    }
                     return;
                 }
 

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Interop/ProcessOwnerLookup.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Interop/ProcessOwnerLookup.cs
@@ -40,19 +40,35 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Interop
         /// process's session. Returns <c>null</c> when the session has no associated user or the
         /// API fails (an empty WTS result is coalesced to <c>null</c>).
         /// </summary>
-        public static string ViaWts(int sessionId)
+        public static string ViaWts(int sessionId) => ViaWts(sessionId, out _);
+
+        /// <summary>
+        /// WTS primary path that also reports whether the API call actually FAILED via
+        /// <paramref name="wtsErrored"/> (L15). A session that simply has no logged-on user yet —
+        /// perfectly normal during OOBE polling — returns <c>null</c> with
+        /// <paramref name="wtsErrored"/> false, so liveness counters no longer inflate the
+        /// "error" rate with routine no-user reads.
+        /// </summary>
+        public static string ViaWts(int sessionId, out bool wtsErrored)
         {
+            wtsErrored = false;
             try
             {
                 var user = WtsNativeMethods.QuerySessionString(sessionId, WtsNativeMethods.WTSUserName);
-                if (string.IsNullOrEmpty(user))
+                if (user == null)
+                {
+                    wtsErrored = true; // API failure (QuerySessionString returns null only then)
                     return null;
+                }
+                if (user.Length == 0)
+                    return null;       // successful query, no user associated yet — not an error
 
                 var domain = WtsNativeMethods.QuerySessionString(sessionId, WtsNativeMethods.WTSDomainName);
                 return string.IsNullOrEmpty(domain) ? user : $"{domain}\\{user}";
             }
             catch
             {
+                wtsErrored = true;
                 return null;
             }
         }

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Telemetry/Analyzers/ConsolePrefetchScanner.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Telemetry/Analyzers/ConsolePrefetchScanner.cs
@@ -37,6 +37,14 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Analyzers
         internal const string CmdPrefetchPattern = "CMD.EXE-*.pf";
         internal const string ConhostPrefetchPattern = "CONHOST.EXE-*.pf";
 
+        /// <summary>
+        /// M5: absorbs the clock-epoch mismatch between the .pf NTFS last-write (stamped under
+        /// the clock at write time) and the boot time derived at scan time as now-minus-uptime
+        /// (shifts with every NTP correction). OOBE clock corrections are typically seconds to a
+        /// few minutes; image/sysprep artifacts predate boot by far more than this.
+        /// </summary>
+        internal static readonly TimeSpan BootClockSkewTolerance = TimeSpan.FromMinutes(10);
+
         private const string Attribution =
             "coarse: a console executed on this device; cannot distinguish a human Shift+F10 from a " +
             "legitimate install-launched cmd once ESP is running (cmd.exe shares one prefetch artifact)";
@@ -107,12 +115,19 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Analyzers
                 return;
             }
 
-            bool ranAfterBoot = cmdArtifact.Value.lastRunUtc > bootTimeUtc.Value;
+            // M5 (delta review 2026-07-02): the two timestamps come from different clock epochs.
+            // The .pf last-write was stamped under the clock at write time; boot time is derived
+            // at SCAN time as now-minus-uptime, so an NTP correction in between (routine during
+            // OOBE) shifts it by the correction amount. A forward correction made a real
+            // Shift+F10 console look pre-boot ("stale image artifact"). The tolerance absorbs
+            // typical OOBE clock corrections; image/sysprep artifacts are hours-to-months older
+            // than boot and stay firmly below it.
+            bool ranAfterBoot = cmdArtifact.Value.lastRunUtc > bootTimeUtc.Value - BootClockSkewTolerance;
             if (!ranAfterBoot)
             {
                 // Stale artifact from the image build / sysprep — not this boot's console.
                 _logger.Debug($"{Name}: cmd prefetch last-run {cmdArtifact.Value.lastRunUtc:o} predates boot " +
-                    $"{bootTimeUtc.Value:o} — stale image artifact, not flagged");
+                    $"{bootTimeUtc.Value:o} (incl. {BootClockSkewTolerance.TotalMinutes:F0} min skew tolerance) — stale image artifact, not flagged");
                 return;
             }
 
@@ -132,14 +147,16 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Analyzers
                 { "coverageComplete", false },
             };
 
-            // Restart dedup: the same artifact + last-run was already reported by a previous agent run
-            // in this enrollment. A NEW cmd run (newer last-run) changes the fingerprint and re-emits.
+            // Restart dedup — once per enrollment (M6, delta review 2026-07-02). The fingerprint
+            // used to include prefetchLastRunUtc + corroboratingArtifacts, but every ESP `cmd /c`
+            // installer wrapper refreshes CMD.EXE-*.pf between reboots, so multi-reboot sessions
+            // re-warned per restart. The scanner cannot distinguish a new human console from
+            // routine installer cmd churn via the artifact timestamp — one Warning per enrollment
+            // is the honest signal; the live ConsoleBypassWatcher covers consoles opened later.
             if (_startupGate != null
-                && !_startupGate.ShouldEmit(
-                    Constants.EventTypes.ConsolePrefetchDetected,
-                    Core.Persistence.StartupEventGate.ComputeFingerprint(data, excludedKeys: new[] { "bootTimeUtc" })))
+                && !_startupGate.ShouldEmit(Constants.EventTypes.ConsolePrefetchDetected, "detected"))
             {
-                _logger.Debug($"{Name}: same cmd prefetch artifact already reported — suppressed (restart dedup)");
+                _logger.Debug($"{Name}: console prefetch already reported this enrollment — suppressed (restart dedup)");
                 return;
             }
 
@@ -158,6 +175,10 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Analyzers
                 ImmediateUpload = true,
                 Data = data,
             });
+
+            // M4: commit the gate claim only after the Warning went out — committing first let a
+            // crash in between suppress this security event for the rest of the enrollment.
+            _startupGate?.MarkEmitted(Constants.EventTypes.ConsolePrefetchDetected);
         }
 
         /// <summary>Newest (max last-write) artifact matching <paramref name="pattern"/>, or null.</summary>

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Telemetry/Analyzers/IntegrityBypassAnalyzer.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Telemetry/Analyzers/IntegrityBypassAnalyzer.cs
@@ -249,6 +249,10 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Analyzers
                     Message = message,
                     Data = data
                 });
+
+                // M4: commit the gate claim only after the emission went out — committing first
+                // let a crash in between suppress the findings for the rest of the enrollment.
+                _startupGate?.MarkEmitted(Constants.EventTypes.IntegrityBypassAnalysis);
             }
             catch (Exception ex)
             {

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Telemetry/Analyzers/LocalAdminAnalyzer.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Telemetry/Analyzers/LocalAdminAnalyzer.cs
@@ -234,6 +234,11 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Analyzers
                     Message   = message,
                     Data      = data
                 });
+
+                // M4: commit the gate claim only after the emission went out — committing first
+                // let a crash in between suppress the findings for the rest of the enrollment.
+                if (trigger == "startup")
+                    _startupGate?.MarkEmitted(Constants.EventTypes.LocalAdminAnalysis);
             }
             catch (Exception ex)
             {

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Telemetry/Analyzers/SoftwareInventoryAnalyzer.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Telemetry/Analyzers/SoftwareInventoryAnalyzer.cs
@@ -111,6 +111,9 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Analyzers
                 }
 
                 EmitInventoryEvents("startup", EnrollmentPhase.Unknown, _startupInventory, null);
+
+                // M4: commit the gate claim only after the (chunked) emission went out.
+                _startupGate?.MarkEmitted(Constants.EventTypes.SoftwareInventoryAnalysis + ":startup");
             }
             catch (Exception ex)
             {

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Telemetry/DeviceInfo/DeviceInfoCollector.NetworkAndSecurity.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Telemetry/DeviceInfo/DeviceInfoCollector.NetworkAndSecurity.cs
@@ -757,6 +757,10 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.DeviceInfo
                 Message = message,
                 Data = data
             });
+
+            // M4: commit the gate claim only after the emission went out (no-op for gate-exempt
+            // event types — they never claimed).
+            _startupGate?.MarkEmitted(eventType);
         }
 
         /// <summary>

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Telemetry/Office/OfficeInstallDetector.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Telemetry/Office/OfficeInstallDetector.cs
@@ -350,6 +350,14 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Office
             // still report. So we emit the informational fact ONCE (idempotent guard) and stay Idle —
             // a later fresh install (enterprise product set, or a real download with no binaries on
             // disk yet) opens a normal started→completed lifecycle from here.
+            //
+            // Accepted risk (L18, delta review 2026-07-02): while inbox binaries are on disk AND
+            // ProductReleaseIds still lists only consumer SKUs, every start trigger short-circuits
+            // here. An enterprise install that fails BEFORE C2R rewrites ProductReleaseIds to a
+            // managed SKU (or before the inbox binaries are removed) therefore never opens a
+            // lifecycle and its INSTALL-scenario error is silently missed. This is silence, never
+            // a false office_install_failed — the trade-off was chosen deliberately over risking
+            // false failure verdicts on routine inbox-Office CLIENTUPDATE churn (session fa526757).
             if (ProbeCoreBinaries(snap.InstallationPath)
                 && OfficeProductClassifier.IsConsumerInboxProductSet(snap.Products))
             {

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Telemetry/Periodic/PerformanceCollector.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Telemetry/Periodic/PerformanceCollector.cs
@@ -26,9 +26,16 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Periodic
         // had no actionable signal. Emit a single disk_space_low Warning on the transition below the
         // threshold; re-arm only after free space recovers past a higher mark (hysteresis) so the
         // event stays state-change-only and never turns into a heartbeat.
+        //
+        // M3 (delta review 2026-07-02): the latch is seeded from + persisted via the
+        // StartupEventGate — a memory-only flag re-warned (ImmediateUpload) after every agent
+        // restart on a persistently disk-starved device (stall restarts: up to ~88×/session).
         private const double DiskLowThresholdGb = 2.0;
         private const double DiskRecoveryThresholdGb = 3.0;
+        private const string DiskLowFingerprint = "low";
+        private const string DiskRearmedFingerprint = "rearmed";
         private bool _diskLowWarned;
+        private readonly Core.Persistence.StartupEventGate _startupGate;
 
         // Network throughput tracking
         private string _activeNicId;
@@ -39,9 +46,14 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Periodic
         private bool _networkInitialized;
 
         public PerformanceCollector(string sessionId, string tenantId, InformationalEventPost post,
-            AgentLogger logger, int intervalSeconds = 60)
+            AgentLogger logger, int intervalSeconds = 60,
+            Core.Persistence.StartupEventGate startupGate = null)
             : base(sessionId, tenantId, post, logger, intervalSeconds)
         {
+            _startupGate = startupGate;
+            // Seed the hysteresis latch from persisted state so a restart on a still-starved
+            // disk does not re-warn (read-only peek — no gate claim).
+            _diskLowWarned = _startupGate?.HasFingerprint(Constants.EventTypes.DiskSpaceLow, DiskLowFingerprint) ?? false;
         }
 
         /// <summary>Use a 5-second warm-up delay so counters are primed before first read.</summary>
@@ -157,9 +169,14 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Periodic
 
                 // MON-B10 — surface a dedicated Warning the moment the drive crosses below the
                 // threshold, instead of leaving the only signal buried in this Debug snapshot.
-                if (EvaluateDiskLowTransition(freeGb, ref _diskLowWarned))
+                if (EvaluateDiskLowTransition(freeGb, ref _diskLowWarned, out var rearmed))
                 {
                     EmitDiskLowWarning(freeGb, totalGb, systemDrive);
+                    PersistDiskLowState(DiskLowFingerprint);
+                }
+                else if (rearmed)
+                {
+                    PersistDiskLowState(DiskRearmedFingerprint);
                 }
             }
             catch (Exception ex)
@@ -289,8 +306,9 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Periodic
         /// <param name="freeGb">Current free space on the system drive, in GB.</param>
         /// <param name="alreadyWarned">Per-collector latch: <c>true</c> while a low-disk warning is in
         /// effect. Updated in place to reflect the new armed state.</param>
-        internal static bool EvaluateDiskLowTransition(double freeGb, ref bool alreadyWarned)
+        internal static bool EvaluateDiskLowTransition(double freeGb, ref bool alreadyWarned, out bool rearmed)
         {
+            rearmed = false;
             if (freeGb < DiskLowThresholdGb)
             {
                 if (alreadyWarned) return false; // still low, already warned → stay quiet
@@ -298,12 +316,26 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Periodic
                 return true;
             }
 
-            if (freeGb >= DiskRecoveryThresholdGb)
+            if (freeGb >= DiskRecoveryThresholdGb && alreadyWarned)
             {
                 alreadyWarned = false; // recovered with margin → re-arm for a future drop
+                rearmed = true;        // caller persists the re-arm so it survives restarts (M3)
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// M3: records the disk-low latch state in the StartupEventGate so it survives agent
+        /// restarts. Uses the gate's claim+commit pair as a persisted state cell — there is no
+        /// separate event emission here (the Warning already went out for the "low" transition;
+        /// the re-arm transition is state-only by design).
+        /// </summary>
+        private void PersistDiskLowState(string fingerprint)
+        {
+            if (_startupGate == null) return;
+            if (_startupGate.ShouldEmit(Constants.EventTypes.DiskSpaceLow, fingerprint))
+                _startupGate.MarkEmitted(Constants.EventTypes.DiskSpaceLow);
         }
 
         private void EmitDiskLowWarning(double freeGb, double totalGb, string drive)

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Telemetry/Security/ConsoleBypassWatcher.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Telemetry/Security/ConsoleBypassWatcher.cs
@@ -42,15 +42,22 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Security
     {
         /// <summary>
         /// Console executables watched. v1 watches only <c>cmd.exe</c> (the exact Shift+F10 spawn); the
-        /// list is the single seam to broaden later (e.g. <c>powershell.exe</c>).
+        /// list is the single seam to broaden later (e.g. <c>powershell.exe</c>) — both the WQL trace
+        /// filter and the startup probe are built from it (L20).
         /// </summary>
         internal static readonly string[] WatchedProcessNames = { "cmd.exe" };
 
-        // cmd switches that turn the shell into a one-shot scripted invocation (install/script), as
-        // opposed to a bare interactive console. Matched as a /c or /k token anywhere in the ARGUMENTS
-        // (the executable path is stripped first) so combined switches like /d/q/c are caught too.
-        private static readonly Regex ScriptSwitchRegex =
-            new Regex(@"/[ck]\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        // /c turns the shell into a one-shot scripted invocation (install/script) — ignored. Matched
+        // as a token anywhere in the ARGUMENTS (the executable path is stripped first) so combined
+        // switches like /d/q/c are caught too.
+        private static readonly Regex RunAndExitSwitchRegex =
+            new Regex(@"/c\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // /k runs its command and then STAYS interactive (L12) — unlike /c this leaves a shell a
+        // human can type into (e.g. a technician-planted `cmd /k whoami`), so it is surfaced as a
+        // low-confidence interactive console instead of being silently ignored.
+        private static readonly Regex RunAndStaySwitchRegex =
+            new Regex(@"/k\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private readonly AgentLogger _logger;
         private readonly Func<int, ProcessProbe?> _processProbe;
@@ -92,24 +99,51 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Security
                 _started = true;
             }
 
+            // L13: both the trace arm and the startup probe are synchronous WMI operations, and
+            // WinMgmt can hang during OOBE (documented failure mode for GetOwner in this repo).
+            // Running them inline stalled the orchestrator's sequential host-start loop and
+            // delayed every host after this one — so they run on a background thread. Exceptions
+            // are contained in StartCore; a disposal racing the background start is handled by
+            // the _disposed re-checks inside.
+            System.Threading.Tasks.Task.Run(() => StartCore());
+        }
+
+        private void StartCore()
+        {
             // 1) ETW-backed push on console creation — armed FIRST so a console spawned during the
             //    startup snapshot below is still caught by the live trace. The _seen set dedups the
             //    overlap (a console that starts mid-arming is seen by both). Arming after the snapshot
             //    would leave a blind gap for a fast cmd that starts between snapshot and arm.
             try
             {
+                var nameFilter = string.Join(" OR ",
+                    Array.ConvertAll(WatchedProcessNames, n => $"ProcessName = '{n}'"));
                 var query = new WqlEventQuery(
-                    "SELECT * FROM Win32_ProcessStartTrace WHERE ProcessName = 'cmd.exe'");
-                _startWatcher = new ManagementEventWatcher(query);
-                _startWatcher.EventArrived += OnProcessStartTrace;
-                _startWatcher.Start();
-                _logger.Info("[ConsoleBypassWatcher] watching Win32_ProcessStartTrace for cmd.exe (interactive-session + bare command line)");
+                    $"SELECT * FROM Win32_ProcessStartTrace WHERE {nameFilter}");
+                var watcher = new ManagementEventWatcher(query);
+                watcher.EventArrived += OnProcessStartTrace;
+
+                lock (_lock)
+                {
+                    if (_disposed)
+                    {
+                        // Dispose won the race against the background start — don't arm.
+                        try { watcher.EventArrived -= OnProcessStartTrace; } catch { }
+                        try { watcher.Dispose(); } catch { }
+                        return;
+                    }
+                    _startWatcher = watcher;
+                }
+
+                watcher.Start();
+                _logger.Info($"[ConsoleBypassWatcher] watching Win32_ProcessStartTrace for " +
+                    $"{string.Join(", ", WatchedProcessNames)} (interactive-session + bare command line)");
             }
             catch (Exception ex)
             {
                 _logger.Warning($"[ConsoleBypassWatcher] could not start WMI process-start watcher " +
                     $"({ex.GetType().Name}: {ex.Message}); relying on the startup probe only.");
-                _startWatcher = null;
+                lock (_lock) { _startWatcher = null; }
                 // Surface the dead live detector so the backend can distinguish it from a clean run.
                 var handler = WatcherArmFailed;
                 try { handler?.Invoke(this, ex); } catch { /* never throw from Start */ }
@@ -120,8 +154,10 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Security
             //    arm so there is no gap; overlap with the live trace is deduped by _seen.
             try
             {
+                var nameFilter = string.Join(" OR ",
+                    Array.ConvertAll(WatchedProcessNames, n => $"Name = '{n}'"));
                 using var searcher = new ManagementObjectSearcher(
-                    "SELECT ProcessId, ParentProcessId, SessionId FROM Win32_Process WHERE Name = 'cmd.exe'");
+                    $"SELECT Name, ProcessId, ParentProcessId, SessionId FROM Win32_Process WHERE {nameFilter}");
                 using var results = searcher.Get();
                 foreach (var mo in results)
                 {
@@ -132,7 +168,8 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Security
                             ToInt(mo["ParentProcessId"]),
                             ToInt(mo["SessionId"]),
                             ownerSidHint: null,
-                            detectedVia: "startup_probe");
+                            detectedVia: "startup_probe",
+                            processName: mo["Name"]?.ToString() ?? WatchedProcessNames[0]);
                     }
                 }
             }
@@ -150,7 +187,8 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Security
                 var parentPid = ToInt(e.NewEvent?["ParentProcessID"]);
                 var sessionId = ToInt(e.NewEvent?["SessionID"]);
                 var ownerSid = TryReadSid(e.NewEvent?["Sid"]); // race-free owner from the trace
-                HandleStart(pid, parentPid, sessionId, ownerSid, "process_start_trace");
+                var processName = e.NewEvent?["ProcessName"]?.ToString() ?? WatchedProcessNames[0];
+                HandleStart(pid, parentPid, sessionId, ownerSid, "process_start_trace", processName);
             }
             catch (Exception ex)
             {
@@ -165,7 +203,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Security
         /// unreadable interactive-session console (instant-close → low confidence). Scripted
         /// invocations (<c>cmd /c</c>) and session-0 (service) cmd are ignored.
         /// </summary>
-        internal void HandleStart(int pid, int parentPid, int sessionId, string? ownerSidHint, string detectedVia)
+        internal void HandleStart(int pid, int parentPid, int sessionId, string? ownerSidHint, string detectedVia, string? processName = null)
         {
             if (pid <= 0) return;
             lock (_lock) { if (_disposed) return; }
@@ -187,47 +225,58 @@ namespace AutopilotMonitor.Agent.V2.Core.Monitoring.Telemetry.Security
             }
 
             bool high = verdict == ConsoleVerdict.InteractiveConsole;
+            string classification;
+            switch (verdict)
+            {
+                case ConsoleVerdict.InteractiveConsole: classification = "interactive_console"; break;
+                case ConsoleVerdict.InteractiveWithCommand: classification = "interactive_console_with_command"; break;
+                default: classification = "interactive_session_unclassified"; break;
+            }
             var info = new ConsoleSpawnInfo(
-                processName: "cmd.exe",
+                processName: processName ?? WatchedProcessNames[0],
                 processId: pid,
                 parentProcessId: parentPid,
                 sessionId: sessionId,
                 owner: probe?.Owner ?? ownerSidHint,
                 commandLine: probe?.CommandLine,
                 confidence: high ? "high" : "low",
-                classification: high ? "interactive_console" : "interactive_session_unclassified",
+                classification: classification,
                 detectedVia: detectedVia);
 
-            _logger.Warning($"[ConsoleBypassWatcher] interactive console detected: cmd.exe (PID={pid}) " +
+            _logger.Warning($"[ConsoleBypassWatcher] interactive console detected: {info.ProcessName} (PID={pid}) " +
                 $"session={sessionId}, confidence={info.Confidence}, via={detectedVia} — possible Shift+F10");
 
             try { BypassConsoleDetected?.Invoke(this, info); }
             catch (Exception ex) { _logger.Warning($"[ConsoleBypassWatcher] handler threw: {ex.Message}"); }
         }
 
-        internal enum ConsoleVerdict { Ignore, InteractiveConsole, UnclassifiedInteractive }
+        internal enum ConsoleVerdict { Ignore, InteractiveConsole, UnclassifiedInteractive, InteractiveWithCommand }
 
         /// <summary>
         /// Pure classification (internal for tests): session-0 → Ignore; a scripted <c>cmd /c</c> →
-        /// Ignore; a bare command line → InteractiveConsole (high); an unreadable command line in an
-        /// interactive session → UnclassifiedInteractive (low, the instant-close fallback).
+        /// Ignore; <c>cmd /k</c> (runs its command, then STAYS interactive — L12) →
+        /// InteractiveWithCommand (low); a bare command line → InteractiveConsole (high); an
+        /// unreadable command line in an interactive session → UnclassifiedInteractive (low, the
+        /// instant-close fallback).
         /// </summary>
         internal static ConsoleVerdict Classify(int sessionId, string? commandLine)
         {
             if (sessionId == 0) return ConsoleVerdict.Ignore;
             if (commandLine == null) return ConsoleVerdict.UnclassifiedInteractive;
-            if (HasScriptArgument(commandLine)) return ConsoleVerdict.Ignore;
+            var arguments = StripExecutable(commandLine);
+            if (RunAndExitSwitchRegex.IsMatch(arguments)) return ConsoleVerdict.Ignore;
+            if (RunAndStaySwitchRegex.IsMatch(arguments)) return ConsoleVerdict.InteractiveWithCommand;
             return ConsoleVerdict.InteractiveConsole;
         }
 
-        /// <summary>True when the command line carries a <c>/c</c> or <c>/k</c> run-command switch
-        /// (a scripted invocation), false for a bare interactive shell. The executable token is
-        /// stripped first so a path can never spoof a switch, and switches may be combined
-        /// (e.g. <c>cmd /d/q/c exit 9</c>).</summary>
+        /// <summary>True when the command line carries a <c>/c</c> run-and-exit switch (a scripted
+        /// invocation), false for a bare interactive shell or a <c>/k</c> run-and-stay shell. The
+        /// executable token is stripped first so a path can never spoof a switch, and switches may
+        /// be combined (e.g. <c>cmd /d/q/c exit 9</c>).</summary>
         internal static bool HasScriptArgument(string commandLine)
         {
             if (string.IsNullOrEmpty(commandLine)) return false;
-            return ScriptSwitchRegex.IsMatch(StripExecutable(commandLine));
+            return RunAndExitSwitchRegex.IsMatch(StripExecutable(commandLine));
         }
 
         /// <summary>Returns the command line with the leading executable token (quoted or

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/CollectorSurfaces.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/CollectorSurfaces.cs
@@ -122,11 +122,13 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
             _imeLogHost?.GetStarvedUserEspApps() ?? Array.Empty<AppPackageState>();
 
         /// <summary>
-        /// Liveness plan PR3 — appIds already reported via <c>app_install_starved</c> on the
-        /// live (esp_exited) path. Consulted by the termination handler so the terminal sweep
-        /// never double-reports an app. Empty when no ESP/Hello host exists.
+        /// Liveness plan PR3 / L6 — atomically claims the <c>app_install_starved</c> report for
+        /// an app against the same dedupe set the live (esp_exited) path uses, so the terminal
+        /// sweep and a racing live emission can never double-report. Returns true when the
+        /// caller owns the report. Without an ESP/Hello host there is no live path to race —
+        /// the claim always succeeds.
         /// </summary>
-        public IReadOnlyCollection<string> StarvedUserEspAppsAlreadyReported =>
-            EspAndHelloHost?.StarvedAppsReported ?? Array.Empty<string>();
+        public bool TryClaimStarvedUserEspAppReport(string appId) =>
+            EspAndHelloHost?.TryClaimStarvedAppReport(appId) ?? true;
     }
 }

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/DecisionStepProcessor.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/DecisionStepProcessor.cs
@@ -45,10 +45,21 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
     /// nächsten Reduce, ebenfalls unlockbar sicher.
     /// </para>
     /// </summary>
-    public sealed class DecisionStepProcessor : IDecisionStepProcessor
+    public sealed class DecisionStepProcessor : IDecisionStepProcessor, IDisposable
     {
         /// <summary>Default — 3 Failures hintereinander → Quarantine.</summary>
         public const int DefaultQuarantineThreshold = 3;
+
+        /// <summary>
+        /// M1 (delta review 2026-07-02) — dwell before the parked tripwire fires. The parked
+        /// predicate is true during a HEALTHY transient window: Classic HelloResolved (or the
+        /// HelloSafety timeout) cancels the only armed deadline and moves to AwaitingDesktop
+        /// seconds-to-minutes before DesktopArrived; firing on the step that produces that state
+        /// is a false alarm AND consumes the one-shot, masking a real variant-4 park later in
+        /// the run. 10 min comfortably clears DesktopArrivalDetector's validation latency while
+        /// staying far below the 360-min max-lifetime watchdog.
+        /// </summary>
+        public static readonly TimeSpan DefaultParkedTripwireDwell = TimeSpan.FromMinutes(10);
 
         /// <summary>
         /// H1a (Wave 2) — the snapshot is a recovery CACHE, not the source of truth (SignalLog +
@@ -77,6 +88,15 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
         private int _passThroughStepsSinceSnapshot; // H1a — pass-through steps skipped since last snapshot
         private bool _parkedTripwireFired; // liveness PR1 — one-shot per agent run, no state-schema touch
 
+        // M1 — parked-tripwire dwell machinery. The timer thread is also what fixes L8: the
+        // tripwire post no longer runs on the ingress worker, so a full channel cannot
+        // self-deadlock on it. Guarded by _parkedLock because the callback races ApplyStep.
+        private readonly object _parkedLock = new object();
+        private readonly TimeSpan _parkedTripwireDwell;
+        private Timer? _parkedDwellTimer;
+        private DecisionSignal? _parkedCandidateSignal;
+        private bool _disposed;
+
         public DecisionStepProcessor(
             DecisionState initialState,
             IJournalWriter journal,
@@ -87,7 +107,8 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
             int quarantineThreshold = DefaultQuarantineThreshold,
             Action<DecisionState>? onTerminalStageReached = null,
             TelemetryTransitionEmitter? transitionEmitter = null,
-            InformationalEventPost? informationalEvents = null)
+            InformationalEventPost? informationalEvents = null,
+            TimeSpan? parkedTripwireDwell = null)
         {
             if (quarantineThreshold <= 0)
             {
@@ -106,6 +127,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
             _onTerminalStageReached = onTerminalStageReached;
             _transitionEmitter = transitionEmitter;
             _informationalEvents = informationalEvents;
+            _parkedTripwireDwell = parkedTripwireDwell ?? DefaultParkedTripwireDwell;
 
             // If recovery loaded a state that already sits on a terminal stage (e.g. a crash
             // after a success-path step but before Stop()), treat it as already-notified so we
@@ -278,16 +300,93 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
             //    arming sites; this invariant check is the tripwire for variant 4. Expected to
             //    NEVER fire in production — every occurrence is a bug report. Skipped on abort
             //    steps: the caller is about to synthesise a terminal signal anyway.
-            if (!_parkedTripwireFired
-                && _informationalEvents != null
-                && !effectResult.SessionMustAbort
-                && IsParkedWithoutDeadline(_currentState))
+            //
+            //    M1 (delta review 2026-07-02): the predicate is true during a HEALTHY transient
+            //    window (HelloResolved → AwaitingDesktop, no deadline, desktop arrives seconds
+            //    later), so a parked state only ARMS a dwell timer here; the tripwire fires —
+            //    and consumes its one-shot — only if the session is STILL parked when the dwell
+            //    elapses. Any step that leaves the parked condition cancels the pending arm.
+            if (_informationalEvents != null && !_parkedTripwireFired)
             {
-                _parkedTripwireFired = true;
-                EmitParkedTripwire(_currentState, signal);
+                if (!effectResult.SessionMustAbort && IsParkedWithoutDeadline(_currentState))
+                    ArmParkedDwell(signal);
+                else
+                    CancelParkedDwell();
             }
 
             return effectResult;
+        }
+
+        /// <summary>
+        /// Arms the parked dwell timer if not already pending. Deliberately does NOT re-base an
+        /// already-armed timer: a truly parked session still produces InformationalEvent
+        /// pass-through steps (perf snapshots, IME telemetry), and re-basing on each of them
+        /// would push the dwell forever. The first parked step of an episode starts the clock;
+        /// only a step that clears the parked condition resets it.
+        /// </summary>
+        private void ArmParkedDwell(DecisionSignal signal)
+        {
+            lock (_parkedLock)
+            {
+                if (_disposed || _parkedTripwireFired || _parkedDwellTimer != null) return;
+                _parkedCandidateSignal = signal;
+                _parkedDwellTimer = new Timer(OnParkedDwellElapsed, null, _parkedTripwireDwell, Timeout.InfiniteTimeSpan);
+            }
+        }
+
+        private void CancelParkedDwell()
+        {
+            lock (_parkedLock)
+            {
+                if (_parkedDwellTimer == null) return;
+                _parkedDwellTimer.Dispose();
+                _parkedDwellTimer = null;
+                _parkedCandidateSignal = null;
+            }
+        }
+
+        private void OnParkedDwellElapsed(object? _)
+        {
+            try
+            {
+                DecisionState state;
+                DecisionSignal? armingSignal;
+                lock (_parkedLock)
+                {
+                    if (_disposed || _parkedTripwireFired || _parkedDwellTimer == null) return;
+                    _parkedDwellTimer.Dispose();
+                    _parkedDwellTimer = null;
+                    armingSignal = _parkedCandidateSignal;
+                    _parkedCandidateSignal = null;
+
+                    // Re-check against the LIVE state: a step that resolved the park in the last
+                    // instant may not have reached CancelParkedDwell yet. _currentState is an
+                    // immutable object written by the single ingress worker; the reference read
+                    // is atomic.
+                    state = _currentState;
+                    if (armingSignal == null || !IsParkedWithoutDeadline(state)) return;
+                    _parkedTripwireFired = true;
+                }
+
+                EmitParkedTripwire(state, armingSignal);
+            }
+            catch (Exception ex)
+            {
+                // Observability must never break anything — and this runs on a timer thread.
+                _logger.Error("DecisionStepProcessor: parked-dwell evaluation failed.", ex);
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_parkedLock)
+            {
+                if (_disposed) return;
+                _disposed = true;
+                _parkedDwellTimer?.Dispose();
+                _parkedDwellTimer = null;
+                _parkedCandidateSignal = null;
+            }
         }
 
         /// <summary>
@@ -327,7 +426,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
             try
             {
                 var census = DecisionStateSignalCensus.Build(state);
-                var data = new Dictionary<string, string>(capacity: 6, comparer: StringComparer.Ordinal)
+                var data = new Dictionary<string, string>(capacity: 7, comparer: StringComparer.Ordinal)
                 {
                     ["stage"] = state.Stage.ToString(),
                     ["stepIndex"] = state.StepIndex.ToString(CultureInfo.InvariantCulture),
@@ -336,13 +435,15 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
                         .ToString("o", CultureInfo.InvariantCulture),
                     ["signalsSeen"] = string.Join(",", census.SignalsSeen),
                     ["armedDeadlines"] = string.Join(",", state.Deadlines.Select(d => d.Name)),
+                    ["dwellSeconds"] = _parkedTripwireDwell.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture),
                 };
 
                 _informationalEvents!.Emit(
                     eventType: Constants.EventTypes.SessionParkedWithoutDeadline,
                     source: "DecisionStepProcessor",
-                    message: $"Session is parked without a resolution-capable deadline at stage {state.Stage} — " +
-                             "no signal is guaranteed to ever re-ask the completion question.",
+                    message: $"Session has been parked without a resolution-capable deadline at stage {state.Stage} " +
+                             $"for {_parkedTripwireDwell.TotalMinutes:F0} min — no signal is guaranteed to ever " +
+                             "re-ask the completion question.",
                     severity: EventSeverity.Warning,
                     immediateUpload: true,
                     data: data);

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/DefaultComponentFactory.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/DefaultComponentFactory.cs
@@ -313,7 +313,8 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
                     idleTimeoutMinutes: collectors.CollectorIdleTimeoutMinutes,
                     networkMetrics: _networkMetrics,
                     agentVersion: _agentVersion,
-                    telemetrySpool: telemetrySpool));
+                    telemetrySpool: telemetrySpool,
+                    startupGate: _startupEventGate)); // M3 — disk_space_low latch survives restarts
             }
 
             // V1 parity (CollectorCoordinator.StartOptionalCollectors:375-382) — wire the

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/DefaultComponentFactory.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/DefaultComponentFactory.cs
@@ -106,6 +106,24 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
 
             // ----- Kernel hosts (always-on; they produce decision signals) --------------------
 
+            // Single-rail refactor (plan §5.8) — DeviceInfoCollector existed in V2.Core but had
+            // no host so the Device-Details UI block was empty in V2 sessions (V1-Parity Issue #2).
+            // Kernel host: always on, not remote-config-gated; fires CollectAll on Start on a
+            // background thread so the agent's critical path is not blocked by WMI queries.
+            //
+            // L9 (delta review 2026-07-02): ORDER MATTERS — this host must start (and subscribe
+            // to SignalPosted) BEFORE the EspAndHelloHost, whose Start can immediately post
+            // EspPhaseChanged(DeviceSetup) from the registry backfill. Created later, the host
+            // missed that trigger and the enrollment-start re-collect never ran on sessions that
+            // failed before the FinalizingSetup/desktop end trigger caught up.
+            hosts.Add(new DeviceInfoHost(
+                sessionId: sessionId,
+                tenantId: tenantId,
+                ingress: ingress,
+                clock: clock,
+                logger: logger,
+                startupGate: _startupEventGate));
+
             // Session caa6cf50 gate-starvation fix: the EspAndHelloTracker's user-ESP-apps-settled
             // probe reads the IME log host, which is constructed further down. Same closure-over-
             // local pattern as realmJoinHost below — null until assigned, and the probe only fires
@@ -227,18 +245,6 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
                     logger: logger);
                 hosts.Add(consoleBypassHost);
             }
-
-            // Single-rail refactor (plan §5.8) — DeviceInfoCollector existed in V2.Core but had
-            // no host so the Device-Details UI block was empty in V2 sessions (V1-Parity Issue #2).
-            // Kernel host: always on, not remote-config-gated; fires CollectAll on Start on a
-            // background thread so the agent's critical path is not blocked by WMI queries.
-            hosts.Add(new DeviceInfoHost(
-                sessionId: sessionId,
-                tenantId: tenantId,
-                ingress: ingress,
-                clock: clock,
-                logger: logger,
-                startupGate: _startupEventGate));
 
             // Provisioning-package (PPKG) scan — kernel host, NOT scan-at-Start. Arms a one-shot
             // scan that fires when the ESP DeviceSetup phase begins (or desktop arrival as the

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/EnrollmentOrchestrator.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/EnrollmentOrchestrator.cs
@@ -974,6 +974,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
             try { _transport?.Dispose(); } catch { /* best-effort */ }
             try { _ingress?.Dispose(); } catch { /* best-effort */ }
             try { _drainCts?.Dispose(); } catch { /* best-effort */ }
+            try { _processor?.Dispose(); } catch { /* best-effort — parked-dwell timer */ }
 
             _logger.Info("EnrollmentOrchestrator: stopped.");
         }

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/Hosts/ConsoleBypassHost.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/Hosts/ConsoleBypassHost.cs
@@ -35,6 +35,8 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
         private readonly InformationalEventPost _post;
         private readonly AgentLogger _logger;
         private readonly ConsoleBypassWatcher _watcher;
+        private readonly SignalIngress? _observableIngress;
+        private Action<AutopilotMonitor.DecisionCore.Signals.DecisionSignalKind, IReadOnlyDictionary<string, string>?>? _signalPostedHandler;
         private int _disposed;
 
         public ConsoleBypassHost(
@@ -54,9 +56,38 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
             _watcher = watcher ?? new ConsoleBypassWatcher(logger);
             _watcher.BypassConsoleDetected += OnBypassConsoleDetected;
             _watcher.WatcherArmFailed += OnWatcherArmFailed;
+            _observableIngress = ingress as SignalIngress;
         }
 
-        public void Start() => _watcher.Start();
+        public void Start()
+        {
+            // L14 fallback: the primary stop path is the DesktopArrivalDetector's real-user-owner
+            // callback (StopForDesktopArrival). If the DAD misses the owner (no-candidate timeout,
+            // detection miss), the watcher would stay armed for the agent's whole remaining
+            // lifetime and flag ordinary post-desktop user consoles. A DesktopArrived or
+            // HelloResolved signal on the decision rail is equally conclusive evidence that OOBE's
+            // Shift+F10 window is over — stop on those too.
+            if (_observableIngress != null)
+            {
+                _signalPostedHandler = OnSignalPosted;
+                _observableIngress.SignalPosted += _signalPostedHandler;
+            }
+
+            _watcher.Start();
+        }
+
+        private void OnSignalPosted(AutopilotMonitor.DecisionCore.Signals.DecisionSignalKind kind, IReadOnlyDictionary<string, string>? payload)
+        {
+            if (kind != AutopilotMonitor.DecisionCore.Signals.DecisionSignalKind.DesktopArrived
+                && kind != AutopilotMonitor.DecisionCore.Signals.DecisionSignalKind.HelloResolved)
+            {
+                return;
+            }
+
+            if (Interlocked.CompareExchange(ref _disposed, 0, 0) == 1) return;
+            _logger.Info($"[ConsoleBypassHost] {kind} observed on the decision rail — Shift+F10 window over, stopping console watcher (fallback stop path)");
+            Dispose();
+        }
 
         public void Stop() => Dispose();
 
@@ -120,6 +151,10 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
         public void Dispose()
         {
             if (Interlocked.Exchange(ref _disposed, 1) == 1) return;
+            if (_observableIngress != null && _signalPostedHandler != null)
+            {
+                try { _observableIngress.SignalPosted -= _signalPostedHandler; } catch { }
+            }
             try { _watcher.BypassConsoleDetected -= OnBypassConsoleDetected; } catch { }
             try { _watcher.WatcherArmFailed -= OnWatcherArmFailed; } catch { }
             try { _watcher.Dispose(); } catch { }

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/Hosts/EspAndHelloHost.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/Hosts/EspAndHelloHost.cs
@@ -54,6 +54,9 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
         /// </summary>
         public System.Collections.Generic.IReadOnlyCollection<string> StarvedAppsReported => _tracker.StarvedAppsReported;
 
+        /// <summary>L6 — atomic claim for the termination sweep (see EspAndHelloTracker.TryClaimStarvedAppReport).</summary>
+        public bool TryClaimStarvedAppReport(string appId) => _tracker.TryClaimStarvedAppReport(appId);
+
         public EspAndHelloHost(
             string sessionId,
             string tenantId,

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/Hosts/PeriodicCollectorLifecycleHost.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/Hosts/PeriodicCollectorLifecycleHost.cs
@@ -54,6 +54,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
         private readonly NetworkMetrics? _networkMetrics;
         private readonly string _agentVersion;
         private readonly ITelemetrySpool? _telemetrySpool;
+        private readonly Persistence.StartupEventGate? _startupGate;
 
         // Codex Finding 4 — reference to the concrete SignalIngress (when available) so we
         // can subscribe to its SignalPosted event. This lets us observe activity from
@@ -86,7 +87,8 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
             int idleTimeoutMinutes,
             NetworkMetrics? networkMetrics,
             string agentVersion,
-            ITelemetrySpool? telemetrySpool = null)
+            ITelemetrySpool? telemetrySpool = null,
+            Persistence.StartupEventGate? startupGate = null)
         {
             if (ingress == null) throw new ArgumentNullException(nameof(ingress));
             if (clock == null) throw new ArgumentNullException(nameof(clock));
@@ -101,6 +103,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
             _networkMetrics = networkMetrics;
             _agentVersion = agentVersion;
             _telemetrySpool = telemetrySpool;
+            _startupGate = startupGate;
             _lastRealEventTimeUtc = DateTime.UtcNow;
 
             // Post goes to the raw ingress — no per-host wrapping. Activity observation
@@ -184,7 +187,8 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
             if (_perfEnabled && _performanceCollector == null)
             {
                 _performanceCollector = new PerformanceCollector(
-                    _sessionId, _tenantId, _post, _logger, _perfIntervalSeconds);
+                    _sessionId, _tenantId, _post, _logger, _perfIntervalSeconds,
+                    startupGate: _startupGate); // M3 — disk_space_low latch survives restarts
                 _performanceCollector.Start();
             }
             if (_selfMetricsEnabled && _selfMetricsCollector == null && _networkMetrics != null)

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/Hosts/UserEspKeepAwakeHost.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/Hosts/UserEspKeepAwakeHost.cs
@@ -84,7 +84,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
         private readonly TimeSpan? _safetyCapOverride;
         private readonly Func<int?> _espTimeoutProvider;
 
-        private enum HoldState { Idle, Engaged, Released }
+        private enum HoldState { Idle, Engaging, Engaged, Released }
 
         private readonly object _gate = new object();
         private Action<DecisionSignalKind, IReadOnlyDictionary<string, string>?>? _signalPostedHandler;
@@ -194,18 +194,21 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
             catch (Exception ex) { _logger.Error("UserEspKeepAwakeHost: release failed.", ex); }
         }
 
-        /// <summary>Engage the hold exactly once (Idle → Engaged). No-op from any other state.</summary>
+        /// <summary>Engage the hold exactly once (Idle → Engaging → Engaged). No-op from any other state.</summary>
         private void Engage()
         {
-            bool osAccepted;
             int capMinutes;
             string capSource;
+            TimeSpan cap;
             lock (_gate)
             {
                 if (_state != HoldState.Idle) return;
+                // L16 (delta review 2026-07-02): claim the transition, but run the controller's
+                // Engage OUTSIDE the lock — it can block up to ~5 s on the keep-awake thread's
+                // ready-wait, and holding _gate across that stalled a concurrent Stop→Release.
+                _state = HoldState.Engaging;
 
                 // Size the cap now (AccountSetup has started, so the ESP policy is in the registry).
-                TimeSpan cap;
                 if (_safetyCapOverride.HasValue)
                 {
                     cap = _safetyCapOverride.Value;
@@ -217,8 +220,21 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
                     (capMinutes, capSource) = ResolveSafetyCapMinutes(SafeReadEspTimeoutMinutes(), _fallbackCapMinutes);
                     cap = TimeSpan.FromMinutes(capMinutes);
                 }
+            }
 
-                osAccepted = _controller.Engage();
+            var osAccepted = _controller.Engage(); // blocking — deliberately outside _gate (L16)
+
+            lock (_gate)
+            {
+                if (_state != HoldState.Engaging)
+                {
+                    // A Release (stop / completion) won the race while the controller was
+                    // engaging. The state is final — undo the OS hold we just acquired.
+                    try { _controller.Release(); }
+                    catch (Exception ex) { _logger.Warning($"UserEspKeepAwakeHost: rollback release failed: {ex.Message}"); }
+                    return;
+                }
+
                 _activeCapMinutes = capMinutes;
                 // One-shot backstop (NOT periodic): fire once after the cap, then release.
                 _safetyCapTimer = new Timer(OnSafetyCapElapsed, null, cap, Timeout.InfiniteTimeSpan);
@@ -245,8 +261,10 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
         }
 
         /// <summary>
-        /// Release the hold exactly once (Idle/Engaged → Released). Idempotent — a second call (or
-        /// a competing completion / cap / stop trigger) is a no-op.
+        /// Release the hold exactly once (Idle/Engaging/Engaged → Released). Idempotent — a second
+        /// call (or a competing completion / cap / stop trigger) is a no-op. A release that lands
+        /// while an Engage is mid-flight (Engaging) wins: the engage path detects the final state
+        /// after its blocking controller call and rolls the OS hold back (L16).
         /// </summary>
         private void Release(string reason, EventSeverity severity, bool emit)
         {

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/RecoveryCoordinator.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Orchestration/RecoveryCoordinator.cs
@@ -109,6 +109,14 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
         public const string QuarantineRequestedMarkerFile = "quarantine-requested.marker";
 
         /// <summary>
+        /// L7 (delta review 2026-07-02): marker-content prefix written when the quarantine was
+        /// performed but the marker file could not be deleted (AV/ACL hold). A marker carrying
+        /// this sentinel means "already handled — retry the delete, do NOT re-quarantine",
+        /// preventing a stuck marker from wiping the fresh run's state on every restart.
+        /// </summary>
+        internal const string QuarantineProcessedSentinel = "processed:";
+
+        /// <summary>
         /// Runs the full recovery pipeline against <paramref name="stateDirectory"/> and returns
         /// the opened writers, seed state, and recovery flags. The directory is assumed to exist
         /// (the orchestrator calls <c>EnsureDirectories</c> first).
@@ -146,6 +154,21 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
             if (File.Exists(quarantineMarkerPath))
             {
                 var quarantineReason = TryReadMarkerReason(quarantineMarkerPath);
+                if (quarantineReason.StartsWith(QuarantineProcessedSentinel, StringComparison.Ordinal))
+                {
+                    // L7 (delta review 2026-07-02): a prior start already PERFORMED this
+                    // quarantine but could not delete the marker (AV/ACL hold) and neutralized
+                    // it with the processed sentinel instead. Re-running the quarantine here
+                    // would wipe the FRESH run's state on every restart — just retry the delete
+                    // and continue with normal recovery.
+                    logger.Warning(
+                        "EnrollmentOrchestrator: neutralized quarantine marker still present — quarantine " +
+                        "already performed by a prior start; retrying marker delete only.");
+                    try { File.Delete(quarantineMarkerPath); }
+                    catch (Exception ex) { logger.Warning($"EnrollmentOrchestrator: quarantine marker delete retry failed: {ex.Message}"); }
+                }
+                else
+                {
                 logger.Error(
                     "EnrollmentOrchestrator: prior-run quarantine marker found — quarantining all state " +
                     $"segments + snapshot before recovery. Reason: {quarantineReason}");
@@ -161,7 +184,24 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
                     // next start retries fail-closed instead of proceeding on possibly-still-corrupt
                     // segments with the retry hint lost.
                     try { File.Delete(quarantineMarkerPath); }
-                    catch (Exception ex) { logger.Warning($"EnrollmentOrchestrator: quarantine marker delete failed: {ex.Message}"); }
+                    catch (Exception deleteEx)
+                    {
+                        logger.Warning($"EnrollmentOrchestrator: quarantine marker delete failed: {deleteEx.Message}");
+                        // L7: the quarantine itself SUCCEEDED — neutralize the stuck marker so the
+                        // next start does not re-wipe fresh state. Best-effort: if the write fails
+                        // too (same ACL hold), behavior degrades to the previous repeated-wipe.
+                        try
+                        {
+                            File.WriteAllText(
+                                quarantineMarkerPath,
+                                QuarantineProcessedSentinel + clock.UtcNow.ToString("o", System.Globalization.CultureInfo.InvariantCulture),
+                                System.Text.Encoding.UTF8);
+                        }
+                        catch (Exception writeEx)
+                        {
+                            logger.Warning($"EnrollmentOrchestrator: quarantine marker neutralization failed: {writeEx.Message}");
+                        }
+                    }
 
                     priorRunQuarantined = true;
                     priorRunQuarantineReason = quarantineReason;
@@ -177,6 +217,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Orchestration
                     logger.Error(
                         "EnrollmentOrchestrator: prior-run quarantine cleanup FAILED — marker retained for "
                         + "next-start retry; forcing a clean Initial seed for this run.", ex);
+                }
                 }
             }
 

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Persistence/StartupEventGate.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Persistence/StartupEventGate.cs
@@ -40,23 +40,36 @@ namespace AutopilotMonitor.Agent.V2.Core.Persistence
         private readonly string _stateFilePath;
         private readonly AgentLogger _logger;
         private readonly object _lock = new object();
+
+        // M4 (delta review 2026-07-02): two views. `_entries` is the in-process truth that
+        // ShouldEmit claims against (immediate, so concurrent/repeated in-process checks stay
+        // deduped). `_persisted` is what actually reaches disk — a key is copied over only by
+        // MarkEmitted/MarkSucceeded, i.e. AFTER the caller's emission went through. Persisting
+        // inside ShouldEmit meant a process death between the fingerprint save and the spool
+        // append suppressed that event for the rest of the enrollment (fail-closed on telemetry,
+        // permanent for static payloads like tpm_info or console_prefetch_detected).
         private readonly Dictionary<string, GateEntry> _entries;
+        private readonly Dictionary<string, GateEntry> _persisted;
 
         public StartupEventGate(string stateDirectory, AgentLogger logger)
         {
             _stateDirectory = Environment.ExpandEnvironmentVariables(stateDirectory);
             _stateFilePath = Path.Combine(_stateDirectory, "startup-event-state.json");
             _logger = logger;
-            _entries = LoadSafe();
+            _persisted = LoadSafe();
+            _entries = new Dictionary<string, GateEntry>(_persisted, StringComparer.Ordinal);
         }
 
         public string StateFilePath => _stateFilePath;
 
         /// <summary>
         /// Emit-on-change: true when no fingerprint is recorded for <paramref name="key"/> or the
-        /// recorded one differs — the new fingerprint is persisted in the same call, so the caller
-        /// emits exactly when this returns true. False means "identical payload already emitted in
-        /// this session" (possibly by a previous agent run).
+        /// recorded one differs. The new fingerprint is claimed IN MEMORY only — the caller must
+        /// invoke <see cref="MarkEmitted"/> after the emission actually went out, which is what
+        /// persists the claim across restarts. A crash (or an emit failure) between the two calls
+        /// therefore re-emits on the next run instead of silently suppressing forever.
+        /// False means "identical payload already emitted in this session" (possibly by a
+        /// previous agent run).
         /// </summary>
         public bool ShouldEmit(string key, string fingerprint)
         {
@@ -75,8 +88,39 @@ namespace AutopilotMonitor.Agent.V2.Core.Persistence
                     Succeeded = existing?.Succeeded ?? false,
                     UpdatedUtc = DateTime.UtcNow,
                 };
-                SaveSafe();
                 return true;
+            }
+        }
+
+        /// <summary>
+        /// Commits the in-memory claim made by the preceding <see cref="ShouldEmit"/> to disk.
+        /// Call after the event emission succeeded. No-op when the key was never claimed
+        /// (e.g. gate-exempt event types).
+        /// </summary>
+        public void MarkEmitted(string key)
+        {
+            if (string.IsNullOrEmpty(key)) return;
+            lock (_lock)
+            {
+                if (!_entries.TryGetValue(key, out var entry)) return;
+                _persisted[key] = entry;
+                SaveSafe();
+            }
+        }
+
+        /// <summary>
+        /// Read-only peek: true when the key's current fingerprint (possibly restored from a
+        /// previous agent run) equals <paramref name="fingerprint"/>. Unlike
+        /// <see cref="ShouldEmit"/> this makes NO claim — use it to seed in-memory latches
+        /// (e.g. the disk_space_low hysteresis) from persisted state at construction time.
+        /// </summary>
+        public bool HasFingerprint(string key, string fingerprint)
+        {
+            if (string.IsNullOrEmpty(key)) return false;
+            lock (_lock)
+            {
+                return _entries.TryGetValue(key, out var entry)
+                    && string.Equals(entry.Fingerprint, fingerprint, StringComparison.Ordinal);
             }
         }
 
@@ -90,19 +134,25 @@ namespace AutopilotMonitor.Agent.V2.Core.Persistence
             }
         }
 
-        /// <summary>Latches a retry-until-success key; subsequent runs skip the probe entirely.</summary>
+        /// <summary>
+        /// Latches a retry-until-success key; subsequent runs skip the probe entirely.
+        /// Persists immediately — success latches happen AFTER the probe's emission by contract
+        /// (see StartupEnvironmentProbes), so there is no suppression window here.
+        /// </summary>
         public void MarkSucceeded(string key)
         {
             if (string.IsNullOrEmpty(key)) return;
             lock (_lock)
             {
                 _entries.TryGetValue(key, out var existing);
-                _entries[key] = new GateEntry
+                var entry = new GateEntry
                 {
                     Fingerprint = existing?.Fingerprint,
                     Succeeded = true,
                     UpdatedUtc = DateTime.UtcNow,
                 };
+                _entries[key] = entry;
+                _persisted[key] = entry;
                 SaveSafe();
             }
         }
@@ -170,7 +220,9 @@ namespace AutopilotMonitor.Agent.V2.Core.Persistence
             {
                 Directory.CreateDirectory(_stateDirectory);
                 var tempPath = _stateFilePath + ".tmp";
-                File.WriteAllText(tempPath, JsonConvert.SerializeObject(_entries));
+                // Persist the committed view only — uncommitted ShouldEmit claims of OTHER keys
+                // must not ride along, or their emissions could be suppressed by a crash too.
+                File.WriteAllText(tempPath, JsonConvert.SerializeObject(_persisted));
                 if (File.Exists(_stateFilePath))
                 {
                     File.Replace(tempPath, _stateFilePath, destinationBackupFileName: null, ignoreMetadataErrors: true);

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Runtime/StartupEnvironmentProbes.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Runtime/StartupEnvironmentProbes.cs
@@ -116,24 +116,36 @@ namespace AutopilotMonitor.Agent.V2.Core.Runtime
                 if (gate == null || !gate.AlreadySucceeded(Constants.EventTypes.DeviceLocation))
                 {
                     SafeEmit(post, logger, BuildGeoEvent(configuration, attempt.Location));
-
-                    // Outbound (public egress) IP — Trace severity so it stays out of the
-                    // timeline by default; persisted/queryable for network correlation.
-                    if (!string.IsNullOrEmpty(attempt.Location.Ip))
-                        SafeEmit(post, logger, BuildOutboundIpEvent(configuration, attempt.Location));
-
                     gate?.MarkSucceeded(Constants.EventTypes.DeviceLocation);
                 }
                 else
                 {
                     logger.Debug("StartupEnvironmentProbes: location re-resolved for the pending timezone retry — device_location already emitted in a previous run.");
                 }
+
+                // Outbound (public egress) IP — Trace severity so it stays out of the timeline by
+                // default; persisted/queryable for network correlation. Own latch (L17): the first
+                // successful provider response can lack the ip field, so it must not ride the
+                // device_location latch — any later lookup (e.g. a timezone retry) that does carry
+                // it still emits the trace once.
+                if (!string.IsNullOrEmpty(attempt.Location.Ip)
+                    && (gate == null || !gate.AlreadySucceeded(Constants.EventTypes.OutboundIp)))
+                {
+                    SafeEmit(post, logger, BuildOutboundIpEvent(configuration, attempt.Location));
+                    gate?.MarkSucceeded(Constants.EventTypes.OutboundIp);
+                }
             }
             else
             {
-                // Failure event each failing start is intentional — it documents the retry trail,
-                // and the unset gate key makes the next agent run try again.
-                SafeEmit(post, logger, BuildGeoFailureEvent(configuration, attempt));
+                // Failure event each failing start is intentional (retry trail) — but only while
+                // the location itself is still outstanding. When a prior run already emitted
+                // device_location and this lookup ran solely to feed the pending timezone retry,
+                // a failure event here would put a device_location failure AFTER its success on
+                // the session timeline (L17) — misleading noise, suppressed.
+                if (gate == null || !gate.AlreadySucceeded(Constants.EventTypes.DeviceLocation))
+                    SafeEmit(post, logger, BuildGeoFailureEvent(configuration, attempt));
+                else
+                    logger.Debug("StartupEnvironmentProbes: geo re-lookup for the pending timezone retry failed — failure event suppressed (location already reported).");
             }
 
             if (configuration.EnableTimezoneAutoSet && !string.IsNullOrEmpty(attempt?.Location?.Timezone))

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/SignalAdapters/ImeLogTrackerAdapter.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/SignalAdapters/ImeLogTrackerAdapter.cs
@@ -847,11 +847,22 @@ namespace AutopilotMonitor.Agent.V2.Core.SignalAdapters
             // script completion so the UI can flag slow / inefficient scripts, not just timed-out
             // ones. Omitted when the start line was never observed (StartedAtUtc null); clamped at 0
             // against clock skew between the (possibly clock-derived) completion stamp and start.
+            //
+            // L19 (delta review 2026-07-02): the same field name carries two different semantics —
+            // platform scripts measure start→result (≈ script runtime), remediation scripts measure
+            // HS-SCRIPT-START→HS-NEW-RESULT (the whole cycle INCLUDING IME's 30 s–3 min batched
+            // reporting latency, i.e. systematically longer than the script ran). `durationBasis`
+            // names which one applies so downstream consumers never compare the two as equals.
             if (script.StartedAtUtc.HasValue)
             {
                 var durationSeconds = (now - script.StartedAtUtc.Value).TotalSeconds;
                 if (durationSeconds >= 0)
+                {
                     data["durationSeconds"] = durationSeconds.ToString("F2", culture);
+                    data["durationBasis"] = IsRemediation(script.ScriptType)
+                        ? "cycle_including_reporting_latency"
+                        : "script_runtime";
+                }
             }
 
             var label = IsRemediation(script.ScriptType) ? "Remediation script" : "Platform script";

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/SignalAdapters/ImeLogTrackerAdapter.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/SignalAdapters/ImeLogTrackerAdapter.cs
@@ -91,9 +91,6 @@ namespace AutopilotMonitor.Agent.V2.Core.SignalAdapters
         // bootstrap marker line. Lets MCP report "which device runs which bootstrap version".
         private bool _bootstrapDetectedPosted;
 
-        // Platform scripts already flagged with script_timeout_suspected (dedup per policyId).
-        private readonly HashSet<string> _scriptTimeoutSuspectedPosted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
         // A platform script whose observed run duration reaches this is treated as having hit the
         // IME script-execution timeout (default ~30 min). 25 min leaves headroom below 30 so clock
         // jitter / the agent's late replay window can't miss it, while staying well above any
@@ -911,7 +908,7 @@ namespace AutopilotMonitor.Agent.V2.Core.SignalAdapters
             var duration = completionUtc - script.StartedAtUtc.Value;
             if (duration < ScriptTimeoutSuspectedThreshold) return;
 
-            if (!_scriptTimeoutSuspectedPosted.Add(script.PolicyId)) return; // dedup per policyId
+            if (!_tracker.TryClaimScriptTimeoutSuspected(script.PolicyId)) return; // restart-safe dedup per policyId (persisted tracker state)
 
             var culture = System.Globalization.CultureInfo.InvariantCulture;
             var shortId = script.PolicyId.Length >= 8 ? script.PolicyId.Substring(0, 8) : script.PolicyId;

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Termination/EnrollmentTerminationHandler.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Termination/EnrollmentTerminationHandler.cs
@@ -84,6 +84,13 @@ namespace AutopilotMonitor.Agent.V2.Core.Termination
         private readonly AgentAnalyzerManager _analyzerManager;
         private readonly InformationalEventPost _post;
         private readonly TimeSpan _lateEventGracePeriod;
+
+        // L4 (delta review 2026-07-02): epoch anchor for boot-time derivation. Captured as a
+        // (monotonic tick, wall clock) pair at construction so the boot timestamp used by the
+        // observation-coverage gate lives in the same clock epoch as AgentStartTimeUtc — an NTP
+        // correction between agent start and termination no longer skews bootToStartSeconds.
+        private readonly ulong _bootAnchorTickMs;
+        private readonly DateTime _bootAnchorUtc;
         private int _handled;
 
         public EnrollmentTerminationHandler(
@@ -117,6 +124,9 @@ namespace AutopilotMonitor.Agent.V2.Core.Termination
             _agentVersion = session.AgentVersion;
             _sessionPersistence = session.SessionPersistence;
             _dialogExePathOverride = session.DialogExePathOverride;
+
+            _bootAnchorTickMs = ObservationCoverage.CurrentTickMs();
+            _bootAnchorUtc = DateTime.UtcNow;
         }
 
         /// <summary>
@@ -339,7 +349,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Termination
                 var packages = TryGetPackageStates();
                 var timings = TryGetAppTimings();
                 var status = FinalStatusBuilder.Build(state, args, packages, _agentStartTimeUtc, timings,
-                    deviceBootUtc: ObservationCoverage.DeviceBootUtc());
+                    deviceBootUtc: ObservationCoverage.DeviceBootUtc(_bootAnchorTickMs, _bootAnchorUtc));
                 SummaryDialogLauncher.WriteAndLaunch(status, _configuration, _stateDirectory, _logger, _dialogExePathOverride);
 
                 if (_configuration.ShowEnrollmentSummary)
@@ -439,13 +449,12 @@ namespace AutopilotMonitor.Agent.V2.Core.Termination
                 var starved = _appTracking.GetStarvedUserEspApps();
                 if (starved == null || starved.Count == 0) return;
 
-                var alreadyReported = _appTracking.StarvedUserEspAppsAlreadyReported
-                    ?? (IReadOnlyCollection<string>)Array.Empty<string>();
-                var reported = new HashSet<string>(alreadyReported, StringComparer.OrdinalIgnoreCase);
-
                 foreach (var app in starved)
                 {
-                    if (app?.Id == null || !reported.Add(app.Id)) continue;
+                    // L6: atomic claim against the live path's dedupe set — the former
+                    // snapshot-then-emit could race a concurrent live app_install_starved
+                    // between copy and emit and double-report the app.
+                    if (app?.Id == null || !_appTracking.TryClaimStarvedUserEspAppReport(app.Id)) continue;
 
                     var name = string.IsNullOrEmpty(app.Name) ? app.Id : app.Name;
                     _logger.Warning(
@@ -590,9 +599,11 @@ namespace AutopilotMonitor.Agent.V2.Core.Termination
         /// </summary>
         private void MaybeEmitAgentLateStart(EnrollmentTerminatedEventArgs args)
         {
+            if (_post == null) return; // L3 — same guard as the sibling emitters
+
             try
             {
-                var deviceBootUtc = ObservationCoverage.DeviceBootUtc();
+                var deviceBootUtc = ObservationCoverage.DeviceBootUtc(_bootAnchorTickMs, _bootAnchorUtc);
                 if (!ObservationCoverage.IsLowObservationCoverage(
                         _agentStartTimeUtc, args.TerminatedAtUtc, deviceBootUtc,
                         out var bootToStartSeconds, out var uptimeSeconds))

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Termination/IAppTrackingReadModel.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Termination/IAppTrackingReadModel.cs
@@ -84,10 +84,12 @@ namespace AutopilotMonitor.Agent.V2.Core.Termination
         IReadOnlyList<AppPackageState>? GetStarvedUserEspApps();
 
         /// <summary>
-        /// Liveness plan PR3 — appIds the live (esp_exited) path already reported via
-        /// <c>app_install_starved</c>. The terminal sweep skips these so the two emission
-        /// paths never double-report an app.
+        /// Liveness plan PR3 / L6 — atomically claims the <c>app_install_starved</c> report for
+        /// <paramref name="appId"/> against the same dedupe set the live (esp_exited) path
+        /// uses. Returns false when either path already reported the app. Replaces the former
+        /// snapshot property: snapshot-then-emit raced a concurrent live emission (TOCTOU) and
+        /// could double-report.
         /// </summary>
-        IReadOnlyCollection<string> StarvedUserEspAppsAlreadyReported { get; }
+        bool TryClaimStarvedUserEspAppReport(string appId);
     }
 }

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Termination/ObservationCoverage.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Termination/ObservationCoverage.cs
@@ -34,10 +34,29 @@ namespace AutopilotMonitor.Agent.V2.Core.Termination
 
         /// <summary>
         /// Device boot time derived from the monotonic uptime counter (immune to wall-clock jumps /
-        /// NTP corrections during enrollment, unlike a stored boot timestamp). Computed at call time.
+        /// NTP corrections during enrollment, unlike a stored boot timestamp). Computed at call time
+        /// — see the anchored overload for why callers comparing against an EARLIER wall-clock
+        /// timestamp should not use this one.
         /// </summary>
         internal static DateTime DeviceBootUtc() =>
             DateTime.UtcNow - TimeSpan.FromMilliseconds(GetTickCount64());
+
+        /// <summary>Monotonic milliseconds since boot — capture alongside a wall-clock timestamp
+        /// to form an epoch anchor for <see cref="DeviceBootUtc(ulong, DateTime)"/>.</summary>
+        internal static ulong CurrentTickMs() => GetTickCount64();
+
+        /// <summary>
+        /// L4 (delta review 2026-07-02): boot time expressed in the clock EPOCH of
+        /// <paramref name="anchorUtc"/> — a wall-clock timestamp captured at the same instant as
+        /// <paramref name="anchorTickMs"/>. The parameterless overload derives boot from
+        /// "now minus uptime" at TERMINATION time, so an NTP correction between agent start and
+        /// termination (routine during OOBE) shifted bootToStart by the correction amount and
+        /// produced false agent_late_start / lowObservationCoverage verdicts against the
+        /// start-time-stamped agentStartUtc. Anchoring at construction pins boot to the same
+        /// epoch the start timestamp lives in.
+        /// </summary>
+        internal static DateTime DeviceBootUtc(ulong anchorTickMs, DateTime anchorUtc) =>
+            anchorUtc - TimeSpan.FromMilliseconds(anchorTickMs);
 
         /// <summary>
         /// Evaluates the coverage gate. <paramref name="bootToStartSeconds"/> and

--- a/src/Agent/AutopilotMonitor.Agent.V2.Core/Termination/OrchestratorAppTrackingReadModel.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2.Core/Termination/OrchestratorAppTrackingReadModel.cs
@@ -43,7 +43,7 @@ namespace AutopilotMonitor.Agent.V2.Core.Termination
         public IReadOnlyList<AppPackageState>? GetStarvedUserEspApps() =>
             _orchestrator.CollectorSurfaces?.GetStarvedUserEspApps();
 
-        public IReadOnlyCollection<string> StarvedUserEspAppsAlreadyReported =>
-            _orchestrator.CollectorSurfaces?.StarvedUserEspAppsAlreadyReported ?? Array.Empty<string>();
+        public bool TryClaimStarvedUserEspAppReport(string appId) =>
+            _orchestrator.CollectorSurfaces?.TryClaimStarvedUserEspAppReport(appId) ?? true;
     }
 }

--- a/src/Agent/AutopilotMonitor.DecisionCore.Tests/AdvisoryCompletionDeadlineTests.cs
+++ b/src/Agent/AutopilotMonitor.DecisionCore.Tests/AdvisoryCompletionDeadlineTests.cs
@@ -345,10 +345,10 @@ namespace AutopilotMonitor.DecisionCore.Tests
         [Fact]
         public void DeadlineFired_WithoutAnyAnchor_DeadEnds()
         {
-            // No advisory recorded AND the only esp_exiting was the intermediate Device→Account
-            // handoff (before AccountSetup entry) — neither arming anchor exists.
+            // Neither anchor fact exists: no advisory recorded and no esp_exiting ever observed.
             var engine = new DecisionEngine();
-            var state = SetupAdvisoryEligibleSession(engine);
+            var state = DecisionState.CreateInitial("sess-noanchor", "tenant-noanchor", T0);
+            state = engine.Reduce(state, MakeSignal(0, DecisionSignalKind.SessionStarted, T0)).NewState;
 
             var step = engine.Reduce(state, DeadlineFired(70, T0.AddMinutes(57.5), DeadlineNames.AdvisoryCompletion));
 
@@ -356,6 +356,44 @@ namespace AutopilotMonitor.DecisionCore.Tests
             Assert.Equal("advisory_completion_without_anchor", step.Transition.DeadEndReason);
             Assert.Empty(step.Effects);
             Assert.Equal(state.Stage, step.NewState.Stage);
+        }
+
+        [Fact]
+        public void DeadlineFired_IntermediateExitOnly_DeadEndsAsStaleNotArmed()
+        {
+            // L5 (delta review 2026-07-02): the anchor is presence-only now — the intermediate
+            // pre-AccountSetup exit plus AccountSetup entry passes the anchor check, and the
+            // UNARMED window is what dead-ends this stray fire.
+            var engine = new DecisionEngine();
+            var state = SetupAdvisoryEligibleSession(engine);
+
+            var step = engine.Reduce(state, DeadlineFired(70, T0.AddMinutes(57.5), DeadlineNames.AdvisoryCompletion));
+
+            Assert.False(step.Transition.Taken);
+            Assert.Equal("advisory_completion_stale_deadline_not_armed", step.Transition.DeadEndReason);
+            Assert.Empty(step.Effects);
+            Assert.Equal(state.Stage, step.NewState.Stage);
+        }
+
+        [Fact]
+        public void DeadlineFired_EspExitVariant_BackdatedExitTimestamp_StillResolves()
+        {
+            // L5 (delta review 2026-07-02): a guard-blocked post-AccountSetup exit whose SOURCE
+            // timestamp predates AccountSetup entry (replayed CMTrace content / clamped clock)
+            // arms the window; the fire must resolve the session, not dead-end on
+            // advisory_completion_without_anchor (which re-opened the idle-until-max-lifetime
+            // dead-end this deadline exists to close).
+            var engine = new DecisionEngine();
+            var state = SetupAdvisoryEligibleSession(engine); // desktop + post-anchor IME evidence
+
+            var armStep = engine.Reduce(state, MakeSignal(50, DecisionSignalKind.EspExiting, T0.AddMinutes(16)));
+            Assert.NotNull(FindDeadline(armStep.NewState, DeadlineNames.AdvisoryCompletion));
+            Assert.True(armStep.NewState.EspFinalExitUtc!.Value < armStep.NewState.AccountSetupEnteredUtc!.Value);
+
+            var step = engine.Reduce(armStep.NewState, DeadlineFired(70, T0.AddMinutes(46), DeadlineNames.AdvisoryCompletion));
+
+            Assert.True(step.Transition.Taken);
+            Assert.Equal(SessionStage.Finalizing, step.NewState.Stage);
         }
 
         [Fact]
@@ -580,13 +618,58 @@ namespace AutopilotMonitor.DecisionCore.Tests
             Assert.Equal(T0.AddMinutes(5), state.ImeUserSessionCompletedUtc!.Value);
             Assert.Equal(10, state.ImeUserSessionCompletedUtc!.SourceSignalOrdinal);
 
-            // A replayed second observation keeps the original anchor.
+            // A replayed second observation keeps the original anchor (no AccountSetup entry
+            // recorded — the post-anchor upgrade rule cannot apply).
             state = engine.Reduce(state, MakeSignal(
                 20, DecisionSignalKind.ImeUserSessionCompleted, T0.AddMinutes(9),
                 new Dictionary<string, string> { [SignalPayloadKeys.ImePatternId] = "IME-USER-SESSION-COMPLETED" })).NewState;
 
             Assert.Equal(T0.AddMinutes(5), state.ImeUserSessionCompletedUtc!.Value);
             Assert.Equal(10, state.ImeUserSessionCompletedUtc!.SourceSignalOrdinal);
+        }
+
+        [Fact]
+        public void ImeUserSessionCompleted_PreAnchorGhost_UpgradedByFirstPostAnchorObservation()
+        {
+            // M2 (delta review 2026-07-02): a defaultuser0 completion observed BEFORE
+            // AccountSetup entry must not permanently poison the conjunction — the first
+            // at-or-after-anchor observation upgrades the fact, then it freezes.
+            var engine = new DecisionEngine();
+            var state = SetupAdvisoryEligibleSession(engine, imeUserSessionCompletedAt: T0.AddMinutes(10));
+            Assert.Equal(T0.AddMinutes(10), state.ImeUserSessionCompletedUtc!.Value); // ghost recorded
+
+            // Real user's IME session completes post-AccountSetup (+17) → upgrade.
+            state = engine.Reduce(state, MakeSignal(
+                45, DecisionSignalKind.ImeUserSessionCompleted, T0.AddMinutes(27),
+                new Dictionary<string, string> { [SignalPayloadKeys.ImePatternId] = "IME-USER-SESSION-COMPLETED" })).NewState;
+            Assert.Equal(T0.AddMinutes(27), state.ImeUserSessionCompletedUtc!.Value);
+            Assert.Equal(45, state.ImeUserSessionCompletedUtc!.SourceSignalOrdinal);
+
+            // Frozen after the upgrade: a third observation does not re-base the genuine stamp.
+            state = engine.Reduce(state, MakeSignal(
+                48, DecisionSignalKind.ImeUserSessionCompleted, T0.AddMinutes(29),
+                new Dictionary<string, string> { [SignalPayloadKeys.ImePatternId] = "IME-USER-SESSION-COMPLETED" })).NewState;
+            Assert.Equal(T0.AddMinutes(27), state.ImeUserSessionCompletedUtc!.Value);
+            Assert.Equal(45, state.ImeUserSessionCompletedUtc!.SourceSignalOrdinal);
+        }
+
+        [Fact]
+        public void DeadlineFired_GhostThenRealImeCompletion_CompletesThroughFinalizing()
+        {
+            // End-to-end M2: ghost pre-anchor completion, then the real user's post-anchor
+            // completion — the AdvisoryCompletion conjunction must hold and the session must
+            // complete instead of resolving Failed on poisoned evidence.
+            var engine = new DecisionEngine();
+            var state = SetupAdvisoryEligibleSession(engine, imeUserSessionCompletedAt: T0.AddMinutes(10));
+            state = engine.Reduce(state, MakeSignal(
+                45, DecisionSignalKind.ImeUserSessionCompleted, T0.AddMinutes(27),
+                new Dictionary<string, string> { [SignalPayloadKeys.ImePatternId] = "IME-USER-SESSION-COMPLETED" })).NewState;
+            state = ApplyEspTerminalFailure(engine, state, ordinal: 50);
+
+            var step = engine.Reduce(state, DeadlineFired(70, T0.AddMinutes(57.5), DeadlineNames.AdvisoryCompletion));
+
+            Assert.Equal(SessionStage.Finalizing, step.NewState.Stage);
+            Assert.Equal("Skipped", step.NewState.HelloOutcome!.Value);
         }
 
         // ================================================== serialization compat ====

--- a/src/Agent/AutopilotMonitor.DecisionCore.Tests/EspFailureAdvisoryDefangTests.cs
+++ b/src/Agent/AutopilotMonitor.DecisionCore.Tests/EspFailureAdvisoryDefangTests.cs
@@ -174,7 +174,8 @@ namespace AutopilotMonitor.DecisionCore.Tests
         public void EspTerminalFailure_AfterAdvisory_PureDuplicateDeadEnds()
         {
             // Pure duplicate: ShellCoreTracker fires after ProvisioningStatusTracker already did
-            // the rich emission. The ShellCoreTrackerAdapter (line 141) always includes
+            // the rich emission. The Shell-Core path (via EspAndHelloTrackerAdapter; the
+            // test-only ShellCoreTrackerAdapter was removed in ARCH-F7) always includes
             // failureType in its payload but never the registry-specific keys (errorCode /
             // failedSubcategory / category) — those come exclusively from the registry path.
             // This test mirrors that production reality so the dead-end gate is exercised

--- a/src/Shared/AutopilotMonitor.DecisionCore/Engine/DecisionEngine.Classic.cs
+++ b/src/Shared/AutopilotMonitor.DecisionCore/Engine/DecisionEngine.Classic.cs
@@ -506,7 +506,8 @@ namespace AutopilotMonitor.DecisionCore.Engine
         /// is a strong UserDriven-v1 indicator), and records the matched pattern id.
         /// <para>
         /// Additionally records <see cref="DecisionState.ImeUserSessionCompletedUtc"/>
-        /// (set-once — the first observation wins, replays keep the original anchor). The fact
+        /// (first post-AccountSetup observation wins — a pre-AccountSetup defaultuser0 stamp is
+        /// upgraded once by the first at-or-after-anchor observation, then frozen). The fact
         /// is NOT a completion trigger here: the IME "user session" can run under
         /// <c>defaultuser0</c>, so the raw signal proves nothing about the real user. The
         /// <c>AdvisoryCompletion</c> deadline handler consumes it lazily inside a correlation
@@ -529,7 +530,22 @@ namespace AutopilotMonitor.DecisionCore.Engine
                 builder.ImeMatchedPatternId = new SignalFact<string>(patternId!, signal.SessionSignalOrdinal);
             }
 
-            if (state.ImeUserSessionCompletedUtc == null)
+            // Recording rule: first POST-AccountSetup observation wins (M2, delta review
+            // 2026-07-02). Plain set-once let an early defaultuser0 completion (pre-AccountSetup
+            // frame) permanently poison the AdvisoryCompletion conjunction — the real user's
+            // later completion was skipped, `imeUserSessionGenuine` could never hold, and a
+            // session with genuine evidence resolved Failed. Upgrade exactly once: a pre-anchor
+            // stamp is replaced by the first at-or-after-anchor observation; a genuine stamp is
+            // never downgraded or re-based. Pure function of (state, signal) — replay-safe.
+            var recordImeUserSession = state.ImeUserSessionCompletedUtc == null;
+            if (!recordImeUserSession
+                && state.AccountSetupEnteredUtc != null
+                && state.ImeUserSessionCompletedUtc!.Value < state.AccountSetupEnteredUtc.Value
+                && signal.OccurredAtUtc >= state.AccountSetupEnteredUtc.Value)
+            {
+                recordImeUserSession = true;
+            }
+            if (recordImeUserSession)
             {
                 builder.ImeUserSessionCompletedUtc = new SignalFact<DateTime>(signal.OccurredAtUtc, signal.SessionSignalOrdinal);
             }

--- a/src/Shared/AutopilotMonitor.DecisionCore/Engine/DecisionEngine.Edge.cs
+++ b/src/Shared/AutopilotMonitor.DecisionCore/Engine/DecisionEngine.Edge.cs
@@ -356,12 +356,17 @@ namespace AutopilotMonitor.DecisionCore.Engine
             var deadlineStillArmed = HasAdvisoryCompletionDeadline(state);
 
             var hasAdvisoryAnchor = state.EspAdvisoryFailureRecordedUtc != null;
-            // The esp-exit arming site only runs for a final exit observed at-or-after
-            // AccountSetup entry; an intermediate Device→Account exit (recorded earlier than
-            // AccountSetupEnteredUtc) does not count as an anchor.
+            // Presence-only anchor (L5, delta review 2026-07-02). The esp-exit arming site only
+            // runs when AccountSetupEnteredUtc is already set, so both facts being present is
+            // the anchor; `deadlineStillArmed` below is what rejects stray timer fires. The old
+            // additional `EspFinalExitUtc >= AccountSetupEnteredUtc` comparison rejected fires
+            // whose arming exit carried a backfilled/out-of-order source timestamp — returning
+            // the session to the idle-until-max-lifetime dead-end this deadline exists to close.
+            // An intermediate Device→Account exit cannot slip in here: it happens BEFORE
+            // AccountSetup entry, never arms the window, and thus dead-ends on
+            // `advisory_completion_stale_deadline_not_armed`.
             var hasEspExitAnchor = state.EspFinalExitUtc != null
-                && state.AccountSetupEnteredUtc != null
-                && state.EspFinalExitUtc.Value >= state.AccountSetupEnteredUtc.Value;
+                && state.AccountSetupEnteredUtc != null;
 
             string? staleReason = null;
             if (!hasAdvisoryAnchor && !hasEspExitAnchor) staleReason = "advisory_completion_without_anchor";


### PR DESCRIPTION
## Summary

Implements every finding from the V2 agent delta review of 2026-07-02 (`tasks/agent-v2-review-2026-07-02.md`, delta `b45384fd..HEAD` since the waves-1-3 baseline): **1 HIGH, 6 MEDIUM, 21 LOW** — in 5 logical commits. L8 rides along with M1; L11 is moot via M6.

### HIGH
- **H1 — duplicate `script_completed` across agent restarts** (`1eb13e30`): the shutdown force-flush emitted an `agentexecutor_fallback` completion, but the emitted-marker set and pending buffer were memory-only — after a restart the tracker parsed IME's later-written `PS-SCRIPT-RESULT` line fresh and emitted a duplicate. Both are now persisted in `ImeTrackerStateData` (null-safe for old state files); pending scripts continue their grace window after a restart. Includes the stale-result guard (L1) and restart-safe `script_timeout_suspected` dedup (L10).

### MEDIUM
- **M1 — parked-tripwire dwell** (`4af0adb3`): `session_parked_without_deadline` fired on the healthy Classic HelloResolved→AwaitingDesktop window and consumed its one-shot, masking real parks. It now arms a 10-min dwell timer and fires only if the session is still parked when it elapses. The post moved off the ingress worker (fixes L8's self-deadlock hazard). Processor is now `IDisposable`, disposed by the orchestrator.
- **M2 — IME evidence upgrade rule** (`4af0adb3`): `ImeUserSessionCompletedUtc` was set-once, so an early defaultuser0 completion permanently failed the AdvisoryCompletion conjunction → wrong `enrollment_failed` verdicts. New rule: first post-AccountSetup observation wins (one upgrade, then frozen; replay-safe).
- **M4 — two-phase StartupEventGate** (`3da26ee8`): `ShouldEmit` used to persist the fingerprint before the caller emitted — a crash in between suppressed the event for the rest of the enrollment. `ShouldEmit` now claims in-memory only; the new `MarkEmitted(key)` commits after the emission, and only the committed view reaches disk. All five consumers updated.
- **M3 — restart-safe `disk_space_low`** (`3da26ee8`): the hysteresis latch was an in-memory bool and re-warned (ImmediateUpload) after every stall restart; it is now seeded from and persisted via the gate.
- **M5/M6 — prefetch scanner** (`3da26ee8`): 10-min clock-skew tolerance on the after-boot test (NTP corrections could swallow real Shift+F10 hits), and the Warning is once-per-enrollment (the old fingerprint contained `prefetchLastRunUtc`, which every ESP `cmd /c` wrapper refreshes → re-warn per reboot).

### LOW (selection)
- **L12–L15, L20** (`c23dc9a3`): `cmd /k` is surfaced as low-confidence `interactive_console_with_command` instead of ignored; WMI arm/probe run on a background thread; DesktopArrived/HelloResolved signals are a fallback stop path; `wtsErrorCount` counts only real API failures (**WTS stays the primary owner-resolution path — unchanged**); `WatchedProcessNames` is a true single seam.
- **L2–L4, L6, L7, L9, L16, L18, L19, L21** (`9582ad8d`): HelloTracker timer ObjectDisposedException window (net48 process-kill) closed; `agent_late_start` clock-epoch anchor; atomic starved-app claim replaces the snapshot TOCTOU; stuck quarantine markers are neutralized instead of re-wiping fresh state every restart; DeviceInfoHost subscribes before EspAndHelloHost posts; keep-awake engage no longer blocks under its gate; `durationBasis` payload discriminator; comment fixes.

### Deliberate behavior changes
- `cmd /k` consoles now produce `oobe_console_spawned` (low confidence) — previously silently ignored.
- `console_prefetch_detected` fires exactly once per enrollment.
- `StartupEventGate` consumers must call `ShouldEmit` **and** `MarkEmitted` (crash between the two re-emits next run, by design).

No new event types (MCP/Web catalog dual-sync unaffected); new payload keys (`durationBasis`, `dwellSeconds`) are additive.

## Test plan
- Full solution build: 0 errors
- `AutopilotMonitor.Agent.V2.Core.Tests`: 1571/1571 (net48)
- `AutopilotMonitor.DecisionCore.Tests`: 423/423 (net8)
- `AutopilotMonitor.SummaryDialog.Tests`: 44/44 (net48)
- New/updated suites: IME script-state persistence (6 new), parked-tripwire dwell semantics (3 new + rework), StartupEventGate two-phase (4 new), prefetch skew/once-per-enrollment (2 new), disk-low re-arm out-flag, console-watcher `/k` classification

Post-deploy watch items are listed in `tasks/todo.md` (parked-tripwire rate ≈ 0, script_completed duplicate rate → 0, `/k` false-positive rate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)