### PR TITLE
Enrollment status reclassification: timeout != failure (AwaitingUser / Incomplete)

### DIFF
--- a/docs/design/enrollment-status-reclassification-plan.md
+++ b/docs/design/enrollment-status-reclassification-plan.md
@@ -51,11 +51,10 @@ timeline AND let the backend terminalize precisely instead of guessing with grac
 - [x] Classifier consumes it: `ExtractRollup.HasAgentEmergencyBreak`; a session carrying the break
       classifies as `Incomplete` NOW (skips the AwaitingUser grace) unless it actually completed.
       Tested. **This is the load-bearing backend consumer.**
-- [ ] **Part B (backend, testable): materialize the timeline event.** `ReportAgentErrorFunction`
-      currently only logs to App Insights. Inject `ISessionRepository`; on
-      `SessionAgeEmergencyBreak`, write an `agent_emergency_break` `EnrollmentEvent` into the stream
-      (Sequence = max+1, idempotent) so it shows in the timeline and the sweep classifier sees it.
-      Add a pure `BuildAgentEmergencyBreakEvent` helper (analog to `BuildSessionTimeoutEvent`) + test.
+- [x] **Part B (backend): materialize the timeline event.** `ReportAgentErrorFunction` now injects
+      `ISessionRepository` and, on `SessionAgeEmergencyBreak`, writes an `agent_emergency_break`
+      `EnrollmentEvent` (Sequence = max+1, idempotent, best-effort) into the stream. Pure
+      `BuildAgentEmergencyBreakEvent` helper (Warning, non-terminal) + tests. Suite: 2685 pass.
 - [ ] **Part C (agent, CI-only — net48, not Linux-buildable here): best-effort emit.** In
       `CheckSessionAgeEmergencyBreak`, before cleanup/exit, send an `AgentErrorReport`
       (`SessionAgeEmergencyBreak`, message w/ session age) via the resilient `EmergencyReporter`.

--- a/docs/design/enrollment-status-reclassification-plan.md
+++ b/docs/design/enrollment-status-reclassification-plan.md
@@ -94,4 +94,10 @@ Backend + stats only — no agent changes, no heartbeat.
 - **Scope:** forward-only first (PR1–PR5) to watch how the first live sessions classify.
   **PR6 backfill is deferred** — run it once forward-only looks good, to heal historical
   crcins.com + platform stats. Remembered follow-up.
-- **`SessionGraceHours` default:** 72h (per-tenant adjustable); revisit after live data.
+- **`SessionGraceHours`:** now **auto-derived** from the agent's absolute cap, not a magic 72h.
+  `effectiveGrace = max(AbsoluteMaxSessionHours + 12h buffer, override)` = **60h** by default
+  (`EnrollmentTimeoutClassifier.ResolveGraceHours`). Rationale: the 48h agent emergency break is
+  *silent* to the backend, so grace must be ≥ that cap and only slightly beyond it. `SessionGraceHours=0`
+  means auto; an override can only raise the floor. `AbsoluteMaxSessionHours` mirrored into TenantConfiguration.
+  - **Follow-up:** wire `TenantConfiguration.AbsoluteMaxSessionHours` down into `AgentConfigResponse` +
+    RemoteConfigMerger so a tenant override reaches the agent too (today the agent still uses its own default 48).

--- a/docs/design/enrollment-status-reclassification-plan.md
+++ b/docs/design/enrollment-status-reclassification-plan.md
@@ -130,9 +130,11 @@ timeline AND let the backend terminalize precisely instead of guessing with grac
   **PR6 backfill is deferred** — run it once forward-only looks good, to heal historical
   crcins.com + platform stats. Remembered follow-up.
 - **`SessionGraceHours`:** now **auto-derived** from the agent's absolute cap, not a magic 72h.
-  `effectiveGrace = max(AbsoluteMaxSessionHours + 12h buffer, override)` = **60h** by default
+  `effectiveGrace = max(AbsoluteMaxSessionHours + 3h buffer, override)` = **51h** by default (48 + 3)
   (`EnrollmentTimeoutClassifier.ResolveGraceHours`). Rationale: the 48h agent emergency break is
   *silent* to the backend, so grace must be ≥ that cap and only slightly beyond it. `SessionGraceHours=0`
-  means auto; an override can only raise the floor. `AbsoluteMaxSessionHours` mirrored into TenantConfiguration.
+  means auto; an override can only raise the floor. `AbsoluteMaxSessionHours` mirrored into TenantConfiguration,
+  but until the agent honors it (follow-up below) the derivation clamps the assumed cap to ≥ the real agent
+  default (48), so a lower override can never drag the grace below the agent's actual runtime.
   - **Follow-up:** wire `TenantConfiguration.AbsoluteMaxSessionHours` down into `AgentConfigResponse` +
     RemoteConfigMerger so a tenant override reaches the agent too (today the agent still uses its own default 48).

--- a/docs/design/enrollment-status-reclassification-plan.md
+++ b/docs/design/enrollment-status-reclassification-plan.md
@@ -41,6 +41,28 @@ Backend + stats only — no agent changes, no heartbeat.
       the sweep itself has ~17 deps, same rationale as `MaintenanceServiceSessionTimeoutEventTests`).
       **Full Functions.Tests: 2670 pass.** End-to-end validated via the live forward-only watch.
 
+## PR-EB — Agent emergency-break event (transparency: close the silent-48h blind spot)
+
+The agent's 48h absolute session-age break (`Program.Guards.CheckSessionAgeEmergencyBreak`)
+writes only a LOCAL marker + cleans up + exits — silent to the backend. Make it visible in the
+timeline AND let the backend terminalize precisely instead of guessing with grace.
+
+- [x] `Constants.EventTypes.AgentEmergencyBreak` + `AgentErrorType.SessionAgeEmergencyBreak`.
+- [x] Classifier consumes it: `ExtractRollup.HasAgentEmergencyBreak`; a session carrying the break
+      classifies as `Incomplete` NOW (skips the AwaitingUser grace) unless it actually completed.
+      Tested. **This is the load-bearing backend consumer.**
+- [ ] **Part B (backend, testable): materialize the timeline event.** `ReportAgentErrorFunction`
+      currently only logs to App Insights. Inject `ISessionRepository`; on
+      `SessionAgeEmergencyBreak`, write an `agent_emergency_break` `EnrollmentEvent` into the stream
+      (Sequence = max+1, idempotent) so it shows in the timeline and the sweep classifier sees it.
+      Add a pure `BuildAgentEmergencyBreakEvent` helper (analog to `BuildSessionTimeoutEvent`) + test.
+- [ ] **Part C (agent, CI-only — net48, not Linux-buildable here): best-effort emit.** In
+      `CheckSessionAgeEmergencyBreak`, before cleanup/exit, send an `AgentErrorReport`
+      (`SessionAgeEmergencyBreak`, message w/ session age) via the resilient `EmergencyReporter`.
+      ⚠️ The guard runs in `AgentBootstrap` *before* auth/`BackendApiClient` construction — needs a
+      minimal emergency client wired at the call site (or move the emit to a point where `auth` exists).
+      May be lost if the device is fully offline — acceptable (best-effort, that case falls back to grace).
+
 ## PR3 — Reconciliation of late completions
 
 - [ ] Allow `Failed` / `Incomplete` / `AwaitingUser` → `Succeeded` when a genuine terminal

--- a/docs/design/enrollment-status-reclassification-plan.md
+++ b/docs/design/enrollment-status-reclassification-plan.md
@@ -2,7 +2,7 @@
 
 > Working copy lives in `tasks/todo.md` (gitignored); this is the tracked, buildable checklist.
 
-Design note: [`docs/design/enrollment-status-reclassification.md`](../docs/design/enrollment-status-reclassification.md)
+Design note: [`docs/design/enrollment-status-reclassification.md`](./enrollment-status-reclassification.md)
 Branch: `claude/crcins-enrollment-failures-ac943m`
 
 Goal: stop the 5h sweep from labelling silent-but-provisioned sessions `Failed`; add a
@@ -11,20 +11,17 @@ Backend + stats only — no agent changes, no heartbeat.
 
 ---
 
-## PR1 — Status model + ESP rollup extraction (foundation)
+## PR1 — Status model + ESP rollup extraction (foundation) ✅ done
 
-- [ ] Add `AwaitingUser` and `Incomplete` to `SessionStatus` enum
-      (`src/Shared/AutopilotMonitor.Shared/Models/SessionApiModels.cs:426`).
-      Keep ordinal order stable (append; do not renumber existing members).
-- [ ] Extend `FailureSnapshotBuilder` to parse `esp_provisioning_status` events and expose
-      the **last** DeviceSetup and AccountSetup rollups: `{ deviceSetupAllSucceeded: bool,
-      accountSetupSucceededCount: int, accountSetupTotal: int, accountSetupAllSucceeded: bool }`.
-      Gate on the subcategory rollup, NOT `categorySucceeded` (always `"in_progress"`).
-- [ ] Extract a pure `ClassifyTimedOutSession(...)` helper (static, unit-testable — mirror
-      the existing `BuildSessionTimeoutEvent` / `DecideAutoAction` pattern in
-      `MaintenanceService.cs`) implementing the decision table (§2 of the design note).
-- [ ] Unit tests: rollup extraction (0/5, 1–4/5, 5/5, missing) + every classification branch,
-      using fixtures under `tests/fixtures/` (e.g. `account-setup-provisioning-complete-v1.json`).
+- [x] Add `AwaitingUser` and `Incomplete` to `SessionStatus` enum
+      (`SessionApiModels.cs`, appended — existing ordinals unchanged).
+- [x] Extend `FailureSnapshotBuilder` to embed the ESP rollup
+      (`deviceSetupAllSucceeded` / `accountSetup{SucceededCount,Total,AllSucceeded}`),
+      schema v2. Gated on the subcategory rollup, NOT `categorySucceeded`.
+- [x] Pure `EnrollmentTimeoutClassifier.ExtractRollup` + `ClassifyTimedOutSession`
+      (new `EnrollmentTimeoutClassifier.cs`) implementing the decision table.
+- [x] Unit tests `EnrollmentTimeoutClassifierTests` (12) — rollup extraction (0/5, 1–4/5,
+      5/5, fallback, missing) + every classification branch. **Full Functions.Tests: 2670 pass.**
 
 ## PR2 — Sweep uses the classifier + grace window
 
@@ -90,7 +87,9 @@ Backend + stats only — no agent changes, no heartbeat.
 ## Review (fill in after implementation)
 - _pending_
 
-## Open questions for @okieselbach
-- [ ] `SessionGraceHours` default — 72h ok, or tie to `SessionTimeoutHours` multiple?
-- [ ] Reporting label for the third state: `Incomplete`, `Unknown`, or `Incomplete/Unknown`?
-- [ ] Backfill (PR6) in scope now, or ship forward-only first and backfill later?
+## Decisions (2026-07-08)
+- **Third state label:** `Incomplete` (enum member `SessionStatus.Incomplete`, badge "Incomplete").
+- **Scope:** forward-only first (PR1–PR5) to watch how the first live sessions classify.
+  **PR6 backfill is deferred** — run it once forward-only looks good, to heal historical
+  crcins.com + platform stats. Remembered follow-up.
+- **`SessionGraceHours` default:** 72h (per-tenant adjustable); revisit after live data.

--- a/docs/design/enrollment-status-reclassification-plan.md
+++ b/docs/design/enrollment-status-reclassification-plan.md
@@ -89,13 +89,17 @@ timeline AND let the backend terminalize precisely instead of guessing with grac
 - [ ] **Deferred to PR5:** Fleet Health payload Incomplete count (its SuccessRate is documented as
       "over all sessions" with equivalence tests — fold the Incomplete surfacing in with the web work).
 
-## PR5 — Web surface
+## PR5 — Web surface ✅ done (typecheck clean)
 
-- [ ] Mirror enum + `isTerminalStatus` (`utils/sessionStatus.ts`): `Incomplete` terminal,
-      `AwaitingUser` non-terminal.
-- [ ] `SessionStatusBadge.tsx` colours/labels for both new states.
-- [ ] Dashboard / Fleet Health cards render the third bucket; failure-rate copy updated.
-- [ ] `lib/__tests__/sessionStatus.test.ts` updated.
+- [x] `utils/sessionStatus.ts`: `isTerminalStatus` includes `Incomplete`; docstring notes AwaitingUser non-terminal.
+- [x] `SessionStatusBadge.tsx`: `Incomplete` = neutral slate (clearly not red), `AwaitingUser` = sky/blue
+      ("still going"); ⏱️ affordance extended to Incomplete (the silence family).
+- [x] Fleet Health: `FleetHealthStats.Incomplete` (C# model + `MetricsMath.BuildFleetHealthPayload`) +
+      web interface + a dedicated slate "Incomplete" stat card (`FleetStatCard` gained a `slate` color);
+      grid widened to 5.
+- [x] Main dashboard KPI row left as-is (its Success Rate is already the honest terminal rate); the third
+      state is surfaced via the badge everywhere, the Fleet Health card, and the metrics summary `incomplete`.
+- [x] Verified: `tsc --noEmit` clean; backend suite 2709 pass.
 
 ## PR6 — Backfill (optional, one-shot)
 

--- a/docs/design/enrollment-status-reclassification-plan.md
+++ b/docs/design/enrollment-status-reclassification-plan.md
@@ -91,8 +91,8 @@ timeline AND let the backend terminalize precisely instead of guessing with grac
 - [x] Daily aggregation (`ComputeUsageMetricsSnapshotAsync`) already uses `Succeeded+Failed` as the
       denominator — no change needed (Incomplete already excluded).
 - [x] Tests `SessionStatusBucketsTests` (bucketing + terminal-only failure-rate). Suite: 2705 pass.
-- [ ] **Deferred to PR5:** Fleet Health payload Incomplete count (its SuccessRate is documented as
-      "over all sessions" with equivalence tests — fold the Incomplete surfacing in with the web work).
+- [x] Fleet Health payload Incomplete count — done in PR5 (`FleetHealthStats.Incomplete` + slate card).
+      Its SuccessRate stays "over all sessions" (documented), only the Incomplete count was added.
 
 ## PR5 — Web surface ✅ done (typecheck clean)
 

--- a/docs/design/enrollment-status-reclassification-plan.md
+++ b/docs/design/enrollment-status-reclassification-plan.md
@@ -55,12 +55,17 @@ timeline AND let the backend terminalize precisely instead of guessing with grac
       `ISessionRepository` and, on `SessionAgeEmergencyBreak`, writes an `agent_emergency_break`
       `EnrollmentEvent` (Sequence = max+1, idempotent, best-effort) into the stream. Pure
       `BuildAgentEmergencyBreakEvent` helper (Warning, non-terminal) + tests. Suite: 2685 pass.
-- [ ] **Part C (agent, CI-only — net48, not Linux-buildable here): best-effort emit.** In
-      `CheckSessionAgeEmergencyBreak`, before cleanup/exit, send an `AgentErrorReport`
-      (`SessionAgeEmergencyBreak`, message w/ session age) via the resilient `EmergencyReporter`.
-      ⚠️ The guard runs in `AgentBootstrap` *before* auth/`BackendApiClient` construction — needs a
-      minimal emergency client wired at the call site (or move the emit to a point where `auth` exists).
-      May be lost if the device is fully offline — acceptable (best-effort, that case falls back to grace).
+- [x] **Part C (agent, net48 — CI/local build only): best-effort emit.** Implemented via a decoupled
+      callback so the guard stays pure and its unit tests are untouched:
+      - `CheckSessionAgeEmergencyBreak` gains an optional `Action onBreakFired = null`, invoked once when
+        the break is confirmed, BEFORE the marker/cleanup, fully swallowed.
+      - New `EmergencyBreakReporter.TrySend` builds a throwaway auth bundle (`BackendClientFactory`) and
+        fires a `SessionAgeEmergencyBreak` `AgentErrorReport` over the resilient emergency channel, bounded
+        to a 5s wait. `AgentBootstrap` wires it (`GetAgentVersion` made `internal`).
+      - Lost if the device is fully offline — acceptable (that case falls back to the grace window).
+      ⚠️ **Not compiled here** (agent targets net48; this container has only the .NET 8 SDK). The Shared
+      `AgentErrorType.SessionAgeEmergencyBreak` value IS verified (it compiled in the Functions build).
+      **@okieselbach to run the net48 agent build locally.**
 
 ## PR3 — Reconciliation of late completions ✅ done
 

--- a/docs/design/enrollment-status-reclassification-plan.md
+++ b/docs/design/enrollment-status-reclassification-plan.md
@@ -75,16 +75,19 @@ timeline AND let the backend terminalize precisely instead of guessing with grac
 - [x] Tests `SessionStatusTransitionTests` (20, full matrix). Suite: 2705 pass (one pre-existing
       timing-flaky maintenance test, green on retry/isolation — unrelated).
 
-## PR4 — Stats / metrics expose 3 states
+## PR4 — Stats / metrics expose 3 states ✅ done (Fleet Health deferred to PR5)
 
-- [ ] `SessionStatusBuckets` (`MetricsMath.cs:317`): explicit `AwaitingUser` + `Incomplete`
-      buckets (out of `Other`).
-- [ ] `SessionStats` (`SessionApiModels.cs:442`): add `IncompleteLastNDays`; failure-rate
-      denominator = `Succeeded + Failed` only.
-- [ ] Fleet Health payload (`MetricsMath.BuildFleetHealthPayload`): count Incomplete
-      separately; keep SuccessRate honest.
-- [ ] Aggregation equivalence tests (`SessionStatsAggregationTests`,
-      `SessionStatsProjectionEquivalenceTests`, `MetricsSummaryProjectionEquivalenceTests`).
+- [x] `SessionStatusBuckets` (`MetricsMath.cs`): explicit `AwaitingUser` + `Incomplete` buckets
+      (out of `Other`); buckets still reconcile to Total by construction.
+- [x] Metrics summary (`GetMetricsSummaryAsync`): surface `awaitingUser` + `incomplete`; **failure
+      rate now `Failed / (Succeeded + Failed)`** — Incomplete + non-terminal excluded from the denominator.
+- [x] `SessionStats` (`SessionApiModels.cs`): add `IncompleteLastNDays`; dashboard `SuccessRatePct`
+      was already terminal-only (`Succeeded/(Succeeded+Failed)`), so Incomplete is excluded there too.
+- [x] Daily aggregation (`ComputeUsageMetricsSnapshotAsync`) already uses `Succeeded+Failed` as the
+      denominator — no change needed (Incomplete already excluded).
+- [x] Tests `SessionStatusBucketsTests` (bucketing + terminal-only failure-rate). Suite: 2705 pass.
+- [ ] **Deferred to PR5:** Fleet Health payload Incomplete count (its SuccessRate is documented as
+      "over all sessions" with equivalence tests — fold the Incomplete surfacing in with the web work).
 
 ## PR5 — Web surface
 

--- a/docs/design/enrollment-status-reclassification-plan.md
+++ b/docs/design/enrollment-status-reclassification-plan.md
@@ -1,0 +1,96 @@
+# Implementation Plan — Enrollment Status Reclassification
+
+> Working copy lives in `tasks/todo.md` (gitignored); this is the tracked, buildable checklist.
+
+Design note: [`docs/design/enrollment-status-reclassification.md`](../docs/design/enrollment-status-reclassification.md)
+Branch: `claude/crcins-enrollment-failures-ac943m`
+
+Goal: stop the 5h sweep from labelling silent-but-provisioned sessions `Failed`; add a
+third terminal state `Incomplete/Unknown`; reconcile late completions to `Succeeded`.
+Backend + stats only — no agent changes, no heartbeat.
+
+---
+
+## PR1 — Status model + ESP rollup extraction (foundation)
+
+- [ ] Add `AwaitingUser` and `Incomplete` to `SessionStatus` enum
+      (`src/Shared/AutopilotMonitor.Shared/Models/SessionApiModels.cs:426`).
+      Keep ordinal order stable (append; do not renumber existing members).
+- [ ] Extend `FailureSnapshotBuilder` to parse `esp_provisioning_status` events and expose
+      the **last** DeviceSetup and AccountSetup rollups: `{ deviceSetupAllSucceeded: bool,
+      accountSetupSucceededCount: int, accountSetupTotal: int, accountSetupAllSucceeded: bool }`.
+      Gate on the subcategory rollup, NOT `categorySucceeded` (always `"in_progress"`).
+- [ ] Extract a pure `ClassifyTimedOutSession(...)` helper (static, unit-testable — mirror
+      the existing `BuildSessionTimeoutEvent` / `DecideAutoAction` pattern in
+      `MaintenanceService.cs`) implementing the decision table (§2 of the design note).
+- [ ] Unit tests: rollup extraction (0/5, 1–4/5, 5/5, missing) + every classification branch,
+      using fixtures under `tests/fixtures/` (e.g. `account-setup-provisioning-complete-v1.json`).
+
+## PR2 — Sweep uses the classifier + grace window
+
+- [ ] `TenantConfiguration.SessionGraceHours` (default 72) + config plumbing.
+- [ ] In `MarkStalledSessionsAsTimedOutAsync` (Stage 2, `MaintenanceService.cs:~360`):
+      replace the hard-coded `SessionStatus.Failed` with `ClassifyTimedOutSession(...)`.
+      - 5h reached, DeviceSetup succeeded, within grace → `AwaitingUser` (non-terminal).
+      - grace expired → `Incomplete`.
+      - AccountSetup all-succeeded / `enrollment_complete` seen → `Succeeded`.
+      - explicit failure event → `Failed` (unchanged).
+- [ ] Keep the synthetic `session_timeout` event + analyze enqueue ONLY for the real
+      `Failed`/`Incomplete` terminal transitions (not for `AwaitingUser`).
+- [ ] `GetStalledSessionsAsync` / `GetAgentSilentSessionsAsync` must re-scan `AwaitingUser`
+      so the grace→`Incomplete` transition fires on a later pass.
+- [ ] Tests: `SessionTimeoutRuleTests` / `MaintenanceServiceSessionTimeoutEventTests` extended
+      for the new target states + grace boundary.
+
+## PR3 — Reconciliation of late completions
+
+- [ ] Allow `Failed` / `Incomplete` / `AwaitingUser` → `Succeeded` when a genuine terminal
+      arrives (`enrollment_complete`, `whiteglove_complete`, AccountSetup all-succeeded).
+      Audit the `UpdateSessionStatusAsync` terminal-guard so ONLY these reconcile signals may
+      upgrade an already-terminal row (no other Failed→X path opens up).
+- [ ] Verify `EventIngestProcessor.Classification.cs` routes a late `enrollment_complete`
+      through this path (it already sets `Succeeded`; confirm the guard).
+- [ ] Tests: `SessionCompletionTimestampTests` + new reconcile test (sweep→Failed, then late
+      `enrollment_complete` → Succeeded).
+
+## PR4 — Stats / metrics expose 3 states
+
+- [ ] `SessionStatusBuckets` (`MetricsMath.cs:317`): explicit `AwaitingUser` + `Incomplete`
+      buckets (out of `Other`).
+- [ ] `SessionStats` (`SessionApiModels.cs:442`): add `IncompleteLastNDays`; failure-rate
+      denominator = `Succeeded + Failed` only.
+- [ ] Fleet Health payload (`MetricsMath.BuildFleetHealthPayload`): count Incomplete
+      separately; keep SuccessRate honest.
+- [ ] Aggregation equivalence tests (`SessionStatsAggregationTests`,
+      `SessionStatsProjectionEquivalenceTests`, `MetricsSummaryProjectionEquivalenceTests`).
+
+## PR5 — Web surface
+
+- [ ] Mirror enum + `isTerminalStatus` (`utils/sessionStatus.ts`): `Incomplete` terminal,
+      `AwaitingUser` non-terminal.
+- [ ] `SessionStatusBadge.tsx` colours/labels for both new states.
+- [ ] Dashboard / Fleet Health cards render the third bucket; failure-rate copy updated.
+- [ ] `lib/__tests__/sessionStatus.test.ts` updated.
+
+## PR6 — Backfill (optional, one-shot)
+
+- [ ] Manual maintenance path to re-classify historical `Failed` 5h-timeouts using the same
+      classifier, so existing stats (crcins.com + platform) heal retroactively.
+- [ ] Dry-run counters logged before any write; gated behind an explicit admin trigger.
+
+---
+
+## Verification
+- [ ] `dotnet test` green across Functions.Tests + Shared/DecisionCore tests.
+- [ ] Re-run the crcins.com window (via MCP `query_raw_events` / `search_sessions`) and confirm
+      the "after" table in the design note within rounding (Failed ~122, Incomplete ~115,
+      +25 reconciled, failure rate ~4–5 %).
+- [ ] Confirm no `AwaitingUser` session ever emits a `session_timeout`/analyze `Failed` artifact.
+
+## Review (fill in after implementation)
+- _pending_
+
+## Open questions for @okieselbach
+- [ ] `SessionGraceHours` default — 72h ok, or tie to `SessionTimeoutHours` multiple?
+- [ ] Reporting label for the third state: `Incomplete`, `Unknown`, or `Incomplete/Unknown`?
+- [ ] Backfill (PR6) in scope now, or ship forward-only first and backfill later?

--- a/docs/design/enrollment-status-reclassification-plan.md
+++ b/docs/design/enrollment-status-reclassification-plan.md
@@ -62,16 +62,18 @@ timeline AND let the backend terminalize precisely instead of guessing with grac
       minimal emergency client wired at the call site (or move the emit to a point where `auth` exists).
       May be lost if the device is fully offline — acceptable (best-effort, that case falls back to grace).
 
-## PR3 — Reconciliation of late completions
+## PR3 — Reconciliation of late completions ✅ done
 
-- [ ] Allow `Failed` / `Incomplete` / `AwaitingUser` → `Succeeded` when a genuine terminal
-      arrives (`enrollment_complete`, `whiteglove_complete`, AccountSetup all-succeeded).
-      Audit the `UpdateSessionStatusAsync` terminal-guard so ONLY these reconcile signals may
-      upgrade an already-terminal row (no other Failed→X path opens up).
-- [ ] Verify `EventIngestProcessor.Classification.cs` routes a late `enrollment_complete`
-      through this path (it already sets `Succeeded`; confirm the guard).
-- [ ] Tests: `SessionCompletionTimestampTests` + new reconcile test (sweep→Failed, then late
-      `enrollment_complete` → Succeeded).
+- [x] `UpdateSessionStatusAsync` terminal-guard replaced by pure `IsTerminalTransitionAllowed`:
+      a genuine completion (`Succeeded`) UPGRADES a prior `Failed`/`Incomplete`/`AwaitingUser`
+      verdict (late reconcile); silent-terminal verdicts + `AwaitingUser` never overwrite a terminal.
+- [x] On `Succeeded`, clear stale `FailureReason` + `FailureSnapshotJson` (reconcile hygiene).
+- [x] Admin-marked terminal decisions are preserved — a late completion does NOT auto-override a
+      hand-marked `Failed`/`Incomplete`.
+- [x] Ingest already routes late `enrollment_complete`/`gather` → `Succeeded` with no pre-terminal
+      skip, so the relaxed guard makes reconcile work end-to-end (no ingest change needed).
+- [x] Tests `SessionStatusTransitionTests` (20, full matrix). Suite: 2705 pass (one pre-existing
+      timing-flaky maintenance test, green on retry/isolation — unrelated).
 
 ## PR4 — Stats / metrics expose 3 states
 

--- a/docs/design/enrollment-status-reclassification-plan.md
+++ b/docs/design/enrollment-status-reclassification-plan.md
@@ -23,21 +23,23 @@ Backend + stats only — no agent changes, no heartbeat.
 - [x] Unit tests `EnrollmentTimeoutClassifierTests` (12) — rollup extraction (0/5, 1–4/5,
       5/5, fallback, missing) + every classification branch. **Full Functions.Tests: 2670 pass.**
 
-## PR2 — Sweep uses the classifier + grace window
+## PR2 — Sweep uses the classifier + grace window ✅ done
 
-- [ ] `TenantConfiguration.SessionGraceHours` (default 72) + config plumbing.
-- [ ] In `MarkStalledSessionsAsTimedOutAsync` (Stage 2, `MaintenanceService.cs:~360`):
-      replace the hard-coded `SessionStatus.Failed` with `ClassifyTimedOutSession(...)`.
-      - 5h reached, DeviceSetup succeeded, within grace → `AwaitingUser` (non-terminal).
-      - grace expired → `Incomplete`.
-      - AccountSetup all-succeeded / `enrollment_complete` seen → `Succeeded`.
-      - explicit failure event → `Failed` (unchanged).
-- [ ] Keep the synthetic `session_timeout` event + analyze enqueue ONLY for the real
-      `Failed`/`Incomplete` terminal transitions (not for `AwaitingUser`).
-- [ ] `GetStalledSessionsAsync` / `GetAgentSilentSessionsAsync` must re-scan `AwaitingUser`
-      so the grace→`Incomplete` transition fires on a later pass.
-- [ ] Tests: `SessionTimeoutRuleTests` / `MaintenanceServiceSessionTimeoutEventTests` extended
-      for the new target states + grace boundary.
+- [x] `TenantConfiguration.SessionGraceHours` (default 72) + default-config plumbing.
+- [x] `MarkStalledSessionsAsTimedOutAsync` (Stage 2): replaced hard-coded `Failed` with
+      `EnrollmentTimeoutClassifier.ClassifyTimedOutSession(...)`. Fast-path skips within-grace
+      `AwaitingUser` sessions with NO event read (grace is time-based). Per-outcome counters +
+      audit/ops only when the pass did something.
+- [x] Synthetic `session_timeout` event + analyze enqueue kept ONLY for `Failed`/`Incomplete`
+      terminal transitions (not `AwaitingUser`/`Succeeded`).
+- [x] `GetStalledSessionsAsync` now includes `AwaitingUser` so grace→`Incomplete` fires later.
+      `GetAgentSilentSessionsAsync` left InProgress-only (no regress).
+- [x] `UpdateSessionStatusAsync`: `Incomplete` treated as terminal (idempotency guard);
+      `AwaitingUser` never regresses a terminal; `CompletedAt` stamped for `Incomplete` (no
+      duration); reason + snapshot persisted for `Incomplete`/`AwaitingUser`.
+- [x] Decision logic + grace boundary covered by `EnrollmentTimeoutClassifierTests` (pure —
+      the sweep itself has ~17 deps, same rationale as `MaintenanceServiceSessionTimeoutEventTests`).
+      **Full Functions.Tests: 2670 pass.** End-to-end validated via the live forward-only watch.
 
 ## PR3 — Reconciliation of late completions
 

--- a/docs/design/enrollment-status-reclassification.md
+++ b/docs/design/enrollment-status-reclassification.md
@@ -112,11 +112,31 @@ Rationale for each bucket sizing is in the Evidence table above.
 
 ### 3. Grace window (backend owns the wait — zero client cost)
 
-Add `TenantConfiguration.SessionGraceHours` (default **72**). Two‑stage terminalization in
-the same sweep that already runs:
+Two‑stage terminalization in the same sweep that already runs:
 
 - At `SessionTimeoutHours` (5h): non‑terminal → **`AwaitingUser`** (was `Failed`).
-- At `SessionGraceHours` (72h): `AwaitingUser` → **`Incomplete`** (unless already reconciled).
+- At the grace window: `AwaitingUser` → **`Incomplete`** (unless already reconciled).
+
+**The grace is anchored to the agent, not a magic number.** The agent has two brakes:
+a **6h per‑run** max‑lifetime (`AgentMaxLifetimeMinutes`, re‑armed each reboot) that emits an
+explicit `enrollment_failed(max_lifetime)` → the session is already `Failed` at ~6h; and a
+**48h absolute session‑age emergency break** (`AbsoluteMaxSessionHours`, cumulative across
+reboots, skipped while WhiteGlove‑paused) that is **silent to the backend** — it writes a local
+marker, cleans up and exits without any terminal event. So a session only stays *non‑terminal*
+past 48h precisely when the agent hit that silent break and is now provably gone.
+
+Therefore the grace must be **≥ the agent's absolute cap** (never terminalize `Incomplete`
+while the agent could still legitimately be enrolling) and only slightly beyond it (once the
+cap has fired + last spooled telemetry has had time to land, silence = dead):
+
+```
+effectiveGrace = max( AbsoluteMaxSessionHours + bufferHours , SessionGraceHours override )
+              = max( 48 + 12 , 0 )  = 60h   (defaults)
+```
+
+`SessionGraceHours` defaults to `0` (auto‑derive) and can only *raise* the grace above the
+floor, never below it (`EnrollmentTimeoutClassifier.ResolveGraceHours`). `AbsoluteMaxSessionHours`
+is mirrored into `TenantConfiguration` so the floor follows any tenant override of the agent cap.
 
 The waiting session is just a table row compared against a timestamp — no process, no
 telemetry, no agent change.

--- a/docs/design/enrollment-status-reclassification.md
+++ b/docs/design/enrollment-status-reclassification.md
@@ -131,12 +131,25 @@ cap has fired + last spooled telemetry has had time to land, silence = dead):
 
 ```
 effectiveGrace = max( AbsoluteMaxSessionHours + bufferHours , SessionGraceHours override )
-              = max( 48 + 12 , 0 )  = 60h   (defaults)
+              = max( 48 + 3 , 0 )  = 51h   (defaults)
 ```
+
+The buffer is deliberately **small (3h)**, not a long straggler‑wait: a completion can only ever
+arrive ≤ the cap (the agent self‑destructs at the cap and sends nothing after), so the buffer only
+has to span one 2h maintenance‑sweep cycle + absorb minor clock skew. The reconcile path heals any
+prematurely‑set `Incomplete` back to `Succeeded`, so a tight buffer costs at most a brief flicker.
 
 `SessionGraceHours` defaults to `0` (auto‑derive) and can only *raise* the grace above the
 floor, never below it (`EnrollmentTimeoutClassifier.ResolveGraceHours`). `AbsoluteMaxSessionHours`
 is mirrored into `TenantConfiguration` so the floor follows any tenant override of the agent cap.
+
+**Agent emergency‑break signal (closes the blind spot).** The 48h break is otherwise silent to the
+backend. The agent best‑effort sends an emergency‑break report (resilient channel — may be lost if
+the device is fully offline); the backend materializes an `agent_emergency_break` timeline event
+from it and treats it as a definitive "agent is gone" signal → terminalize **now** by the ESP rollup
+(Account Setup all‑succeeded → `Succeeded`, else `Incomplete`), skipping the grace wait. With this
+signal the grace/buffer only governs the *truly silent* death (bluescreen / power‑cut with no
+network), where no event can ever be sent.
 
 The waiting session is just a table row compared against a timestamp — no process, no
 telemetry, no agent change.

--- a/docs/design/enrollment-status-reclassification.md
+++ b/docs/design/enrollment-status-reclassification.md
@@ -1,0 +1,169 @@
+# Enrollment Status Reclassification — Timeout ≠ Failure
+
+**Status:** Proposal · **Owner:** Backend · **Trigger tenant:** crcins.com (`ca9e3c59-d8ec-4ee6-9544-05f62f85ac98`)
+
+## Problem
+
+The 5‑hour maintenance sweep marks every silent, non‑terminal session as **`Failed`**
+([`MaintenanceService.MarkStalledSessionsAsTimedOutAsync`](../../src/Backend/AutopilotMonitor.Functions/Services/MaintenanceService.cs) — Stage 2 hard‑codes `SessionStatus.Failed`). This conflates
+*"the agent stopped sending telemetry"* with *"the enrollment failed"* and produces a
+massively inflated failure rate.
+
+For crcins.com this is dramatic, but the mechanism is platform‑wide.
+
+## Evidence (crcins.com, 90‑day window)
+
+Reported failure rate **57.2 %** (1321 / 2310). Measured over the full failed population
+(n = 1311) via `query_raw_events(eventType=esp_provisioning_status)` + `search_sessions`:
+
+| Failure reason | Count | Share |
+|---|---:|---:|
+| **`Session timed out after 5 hours`** (no terminal event) | **1189** | **90.7 %** |
+| ESP `WhiteGlove_Failed` | 37 | 2.8 % |
+| Agent max‑lifetime | 35 | 2.7 % |
+| `esp_terminal_failure` | 27 | 2.1 % |
+| `Autopilot enrollment failed: Provisioning…` | 19 | 1.4 % |
+| `esp_exit_without_completion` | 4 | 0.3 % |
+
+**Explicit, real failures ≈ 87 → true failure rate ≈ 3.8 % (max ~5.3 %), not 57.2 %.**
+
+### What the "5h timeouts" actually were
+
+Last observed ESP state across the 1189 timeouts (1077 with captured
+`esp_provisioning_status`, 90.6 % coverage):
+
+| Last observed state | Count | Verdict |
+|---|---:|---|
+| **DeviceSetup 4/4 = fully provisioned (AADJ+MDM)** | **1067 / 1077 (99.1 %)** | device is enrolled |
+| AccountSetup `0/5` — user phase never observed | 1024 (95.1 %) | **AwaitingUser** — not a failure |
+| AccountSetup `1–4/5` — mid user phase, agent gone | 25 (2.3 %) | **AwaitingUser** |
+| AccountSetup `5/5` — complete | 25 (2.3 %) | **reconcile → Succeeded** |
+| no `esp_provisioning_status` at all | 112 (9.4 %) | **Incomplete/Unknown** |
+
+Not a single 5h‑timeout carries an explicit `enrollment_failed` / `esp_failure` event.
+
+### Two key data facts (drive the design)
+
+1. **`categorySucceeded` is unreliable.** In every `esp_provisioning_status` payload —
+   even at DeviceSetup 4/4 and AccountSetup 5/5 — Windows reports
+   `categorySucceeded = "in_progress"`. The agent already compensates with a 30 s
+   "all subcategories succeeded → treat complete" fallback for DeviceSetup
+   ([`ProvisioningStatusTracker` / `EspAndHelloTracker`](../../src/Agent/AutopilotMonitor.Agent.V2.Core/Monitoring/Enrollment/SystemSignals/)).
+   → **Gate on the subcategory rollup, never on `categorySucceeded`.**
+2. **Desktop arrival ≠ complete.** In User‑driven ESP the desktop appears while the
+   Account/user phase is still running. `desktop_arrived` is a hint, not a terminal.
+   The authoritative terminal is **AccountSetup subcategory rollup = all succeeded**
+   (which precedes the agent's own `enrollment_complete`).
+
+## Root cause
+
+The agent captures exactly the right signal (`esp_provisioning_status` with per‑category
+subcategory rollups incl. AccountSetup), but:
+
+- In ~95 % of timeouts the agent goes dark at the DeviceSetup→AccountSetup reboot,
+  **before** the user logs in, so AccountSetup never progresses in telemetry (0/5). The
+  user phase legitimately completes hours/days later (proven by session
+  `cfa820da-…`: AccountSetup 5/5 + `enrollment_complete` the **next day**).
+- The backend's 5h sweep fires first, hard‑labels `Failed`, and **never reconciles** when
+  the late completion arrives.
+
+So the fix is **classification + reconciliation in the backend** — no new agent load,
+no heartbeat. The signals are already in the event stream.
+
+## Design
+
+### 1. Status model — a third terminal bucket
+
+`SessionStatus` ([`SessionApiModels.cs:426`](../../src/Shared/AutopilotMonitor.Shared/Models/SessionApiModels.cs))
+today: `InProgress, Pending, Stalled, Succeeded, Failed, Unknown`.
+
+Add:
+
+- **`AwaitingUser`** (non‑terminal): DeviceSetup succeeded, user/account phase not yet
+  complete, agent silent but within grace. Can heal to `Succeeded` or expire to `Incomplete`.
+- **`Incomplete`** (terminal, **non‑failure**): grace expired with no terminal evidence,
+  or silence before DeviceSetup completed with no explicit failure. This is the
+  "success/failed/**incomplete‑unknown**" third state for the stats. (Existing `Unknown`
+  is folded into the Incomplete bucket for reporting.)
+
+### 2. Classification at the sweep (deterministic, from data we already load)
+
+The sweep already loads up to 1000 events and builds a snapshot
+([`FailureSnapshotBuilder`](../../src/Backend/AutopilotMonitor.Functions/Services/FailureSnapshotBuilder.cs)).
+Extend the snapshot to extract the **last DeviceSetup and AccountSetup subcategory rollups**
+from `esp_provisioning_status` events, then decide the target status instead of hard‑coding
+`Failed`:
+
+```
+Given a non-terminal session past the inactivity window:
+
+1. Explicit enrollment_failed / esp_failure present            → Failed          (real)
+2. AccountSetup rollup = ALL subcategories succeeded
+   OR enrollment_complete / whiteglove_complete present         → Succeeded       (reconcile)
+3. DeviceSetup rollup = ALL subcategories succeeded (or 30s
+   fallback) AND no failure event:
+      a. within grace (now - StartedAt < SessionGraceHours)      → AwaitingUser    (non-terminal)
+      b. grace expired                                           → Incomplete      (terminal, non-failure)
+4. else (silence before DeviceSetup complete, no failure)       → Incomplete
+```
+
+Rationale for each bucket sizing is in the Evidence table above.
+⚠️ Gate step 2/3 on the **subcategory rollup**, not `categorySucceeded`.
+
+### 3. Grace window (backend owns the wait — zero client cost)
+
+Add `TenantConfiguration.SessionGraceHours` (default **72**). Two‑stage terminalization in
+the same sweep that already runs:
+
+- At `SessionTimeoutHours` (5h): non‑terminal → **`AwaitingUser`** (was `Failed`).
+- At `SessionGraceHours` (72h): `AwaitingUser` → **`Incomplete`** (unless already reconciled).
+
+The waiting session is just a table row compared against a timestamp — no process, no
+telemetry, no agent change.
+
+### 4. Reconciliation on late events
+
+When a session in `Failed` / `Incomplete` / `AwaitingUser` later receives a genuine terminal
+signal (`enrollment_complete`, `whiteglove_complete`, or AccountSetup rollup = all
+succeeded), flip to **`Succeeded`**
+([`EventIngestProcessor.Classification.cs`](../../src/Backend/AutopilotMonitor.Functions/Services/EventIngestProcessor.Classification.cs)
+already routes `enrollment_complete` → `Succeeded`; the `UpdateSessionStatusAsync` guard must
+permit an already‑terminal → `Succeeded` upgrade for these reconcile signals only).
+
+### 5. Stats / metrics — expose 3 states, exclude Incomplete from failure rate
+
+- `SessionStatusBuckets` ([`MetricsMath.cs:317`](../../src/Backend/AutopilotMonitor.Functions/Helpers/MetricsMath.cs))
+  gains explicit `AwaitingUser` and `Incomplete` buckets (they currently fall into `Other`).
+- `SessionStats` / Fleet Health: add `IncompleteLastNDays`; **failure rate denominator =
+  `Succeeded + Failed` only** (Incomplete and AwaitingUser excluded). Headline becomes
+  Success / Failed / Incomplete‑Unknown.
+- Web: `SessionStatus` mirror + badge + `isTerminalStatus`
+  ([`utils/sessionStatus.ts`](../../src/Web/autopilot-monitor-web/utils/sessionStatus.ts),
+  [`SessionStatusBadge.tsx`](../../src/Web/autopilot-monitor-web/components/SessionStatusBadge.tsx)).
+
+## Expected impact (crcins.com, from the measured buckets)
+
+| | today | after |
+|---|---:|---:|
+| Succeeded | 599 | ~624 (+25 reconciled) |
+| Failed | 1311 | ~122 (explicit failures + max‑lifetime) |
+| AwaitingUser (new, transient) | – | ~1052 |
+| Incomplete/Unknown (new) | – | ~115 |
+| **Failure rate** | **57.2 %** | **~4–5 %** |
+
+Platform‑wide the same reclassification de‑noises every tenant's failure rate.
+
+## Non‑goals / explicitly rejected
+
+- **Agent heartbeat** — rejected: continuous client load + zombie risk; the completion
+  truth is already persisted (registry/ESP tracking survives reboots) and the wait belongs
+  in the backend.
+- **`desktop_arrived` as completion** — rejected: fires while the user phase is still running.
+
+## Acceptance criteria
+
+- No non‑terminal session is marked `Failed` by the sweep without an explicit failure event.
+- A session reaching AccountSetup all‑succeeded (or `enrollment_complete`) after a prior
+  sweep ends as `Succeeded`.
+- `Failed` count only contains explicit‑failure sessions; failure‑rate excludes Incomplete.
+- Reprocessing the crcins.com window reproduces the "after" table within rounding.

--- a/src/Agent/AutopilotMonitor.Agent.V2/Program.Guards.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2/Program.Guards.cs
@@ -253,7 +253,8 @@ namespace AutopilotMonitor.Agent.V2
             bool selfDestructOnComplete,
             Func<CleanupService> cleanupServiceFactory,
             AgentLogger logger,
-            bool consoleMode)
+            bool consoleMode,
+            Action onBreakFired = null)
         {
             try
             {
@@ -286,6 +287,14 @@ namespace AutopilotMonitor.Agent.V2
                 logger.Warning($"EMERGENCY BREAK: session age {sessionAgeHours:F1}h exceeds maximum {absoluteMaxSessionHours}h — forcing cleanup.");
                 if (consoleMode)
                     Console.Out.WriteLine($"EMERGENCY: Session is {sessionAgeHours:F1}h old (max: {absoluteMaxSessionHours}h). Forcing cleanup.");
+
+                // Best-effort: tell the backend the agent is emergency-breaking so the otherwise-silent
+                // 48h absolute cap is no longer a blind spot in the timeline
+                // (docs/design/enrollment-status-reclassification.md). Fired BEFORE cleanup, while the
+                // session state and network are still intact. Never throws — a send failure (e.g. no
+                // network) must not block the cleanup/exit that is the whole point of this guard.
+                try { onBreakFired?.Invoke(); }
+                catch (Exception cbEx) { logger.Debug($"Emergency-break notify callback failed: {cbEx.Message}"); }
 
                 // Write enrollment-complete.marker so the next start exits cleanly even if
                 // the cleanup retry below fails (Scheduled Task still alive, files locked, …).

--- a/src/Agent/AutopilotMonitor.Agent.V2/Program.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2/Program.cs
@@ -463,7 +463,9 @@ namespace AutopilotMonitor.Agent.V2
             Console.Out.WriteLine(GetAgentVersion());
         }
 
-        private static string GetAgentVersion()
+        // internal (not private) so AgentBootstrap can stamp the best-effort emergency-break report
+        // with the running agent version (docs/design/enrollment-status-reclassification.md).
+        internal static string GetAgentVersion()
         {
             try
             {

--- a/src/Agent/AutopilotMonitor.Agent.V2/Runtime/AgentBootstrap.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2/Runtime/AgentBootstrap.cs
@@ -83,7 +83,10 @@ namespace AutopilotMonitor.Agent.V2.Runtime
             if (Program.CheckSessionAgeEmergencyBreak(
                     dataDirectory, stateSubdir,
                     agentConfig.AbsoluteMaxSessionHours, agentConfig.SelfDestructOnComplete,
-                    cleanupServiceFactory, logger, consoleMode))
+                    cleanupServiceFactory, logger, consoleMode,
+                    // Best-effort: surface the otherwise-silent 48h break to the backend before cleanup
+                    // (docs/design/enrollment-status-reclassification.md). Never blocks the exit.
+                    onBreakFired: () => EmergencyBreakReporter.TrySend(agentConfig, Program.GetAgentVersion(), logger)))
             {
                 logger.Info("Emergency break fired — agent exiting.");
                 return BootstrapResult.Exit(0);

--- a/src/Agent/AutopilotMonitor.Agent.V2/Runtime/EmergencyBreakReporter.cs
+++ b/src/Agent/AutopilotMonitor.Agent.V2/Runtime/EmergencyBreakReporter.cs
@@ -1,0 +1,42 @@
+using System;
+using AutopilotMonitor.Agent.V2.Core.Configuration;
+using AutopilotMonitor.Agent.V2.Core.Logging;
+using AutopilotMonitor.Shared.Models;
+
+namespace AutopilotMonitor.Agent.V2.Runtime
+{
+    /// <summary>
+    /// Best-effort emitter for the agent's absolute session-age emergency break. The break
+    /// (<c>Program.Guards.CheckSessionAgeEmergencyBreak</c>) tears the agent down before the normal
+    /// telemetry pipeline exists, so we build a throwaway auth bundle and fire a single
+    /// <see cref="AgentErrorType.SessionAgeEmergencyBreak"/> report over the resilient emergency
+    /// channel. The backend materializes an <c>agent_emergency_break</c> timeline event from it
+    /// (<c>ReportAgentErrorFunction</c>), closing the silent-48h blind spot and letting the timeout
+    /// classifier terminalize the session instead of waiting out the grace. Fully swallowed — a send
+    /// failure (no network, no cert) must never delay the cleanup/exit the break exists to perform.
+    /// See docs/design/enrollment-status-reclassification.md.
+    /// </summary>
+    internal static class EmergencyBreakReporter
+    {
+        public static void TrySend(AgentConfiguration agentConfig, string agentVersion, AgentLogger logger)
+        {
+            try
+            {
+                var auth = BackendClientFactory.BuildAuthClients(agentConfig, agentVersion, logger);
+                var message =
+                    $"Agent absolute session-age emergency break fired (cap {agentConfig.AbsoluteMaxSessionHours}h) — cleaning up and exiting.";
+
+                // The process is about to exit, so block briefly on the otherwise fire-and-forget send
+                // rather than let it be abandoned mid-flight. TrySendAsync swallows its own HTTP errors;
+                // the auth bundle's HttpClients are intentionally left for process teardown.
+                auth.EmergencyReporter
+                    .TrySendAsync(AgentErrorType.SessionAgeEmergencyBreak, message)
+                    .Wait(TimeSpan.FromSeconds(5));
+            }
+            catch (Exception ex)
+            {
+                logger?.Debug($"Emergency-break report send failed (best-effort): {ex.Message}");
+            }
+        }
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions.Tests/EnrollmentTimeoutClassifierTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/EnrollmentTimeoutClassifierTests.cs
@@ -85,6 +85,27 @@ public class EnrollmentTimeoutClassifierTests
         Assert.True(EnrollmentTimeoutClassifier.ExtractRollup(new[] { Evt("esp_failure") }).HasExplicitFailure);
         Assert.True(EnrollmentTimeoutClassifier.ExtractRollup(new[] { Evt("enrollment_complete") }).HasTerminalComplete);
         Assert.True(EnrollmentTimeoutClassifier.ExtractRollup(new[] { Evt("whiteglove_complete") }).HasTerminalComplete);
+        Assert.True(EnrollmentTimeoutClassifier.ExtractRollup(new[] { Evt("agent_emergency_break") }).HasAgentEmergencyBreak);
+    }
+
+    [Fact]
+    public void Classify_emergency_break_skips_grace_and_is_Incomplete()
+    {
+        // Agent reported its absolute-age break → it's gone. Even DeviceSetup-done + well within grace
+        // must NOT wait as AwaitingUser; the honest verdict is Incomplete right now.
+        var (status, reason) = Classify(
+            new[] { Esp(DeviceSetup44), Esp(AccountSetup05), Evt("agent_emergency_break") }, hoursSinceStart: 6);
+        Assert.Equal(SessionStatus.Incomplete, status);
+        Assert.Contains("emergency break", reason);
+    }
+
+    [Fact]
+    public void Classify_emergency_break_still_yields_to_a_real_completion()
+    {
+        // If the session actually completed, that wins over the break marker.
+        var (status, _) = Classify(
+            new[] { Esp(DeviceSetup44), Esp(AccountSetup55), Evt("agent_emergency_break") }, hoursSinceStart: 6);
+        Assert.Equal(SessionStatus.Succeeded, status);
     }
 
     // -------- ClassifyTimedOutSession --------

--- a/src/Backend/AutopilotMonitor.Functions.Tests/EnrollmentTimeoutClassifierTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/EnrollmentTimeoutClassifierTests.cs
@@ -144,13 +144,13 @@ public class EnrollmentTimeoutClassifierTests
     // -------- ResolveGraceHours --------
 
     [Theory]
-    [InlineData(null, null, 60)] // defaults: 48 + 12
-    [InlineData(0, null, 60)]    // 0 override = auto-derive
-    [InlineData(0, 48, 60)]      // explicit agent cap = default
-    [InlineData(0, 96, 108)]     // bigger agent cap → grace follows (96 + 12)
-    [InlineData(0, 0, 60)]       // agent cap 0/invalid → fall back to default 48
+    [InlineData(null, null, 51)] // defaults: 48 + 3
+    [InlineData(0, null, 51)]    // 0 override = auto-derive
+    [InlineData(0, 48, 51)]      // explicit agent cap = default
+    [InlineData(0, 96, 99)]      // bigger agent cap → grace follows (96 + 3)
+    [InlineData(0, 0, 51)]       // agent cap 0/invalid → fall back to default 48
     [InlineData(90, 48, 90)]     // override ABOVE the floor wins
-    [InlineData(30, 48, 60)]     // override BELOW the floor is clamped up to the floor
+    [InlineData(30, 48, 51)]     // override BELOW the floor is clamped up to the floor
     public void ResolveGraceHours_floors_at_agent_cap_plus_buffer(int? configured, int? absoluteMax, int expected)
     {
         Assert.Equal(expected, EnrollmentTimeoutClassifier.ResolveGraceHours(configured, absoluteMax));

--- a/src/Backend/AutopilotMonitor.Functions.Tests/EnrollmentTimeoutClassifierTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/EnrollmentTimeoutClassifierTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using AutopilotMonitor.Functions.Services;
+using AutopilotMonitor.Shared.Models;
+
+namespace AutopilotMonitor.Functions.Tests;
+
+/// <summary>
+/// Tests for the timeout reclassification (docs/design/enrollment-status-reclassification.md).
+/// The maintenance sweep must stop labelling every silent session Failed: a session whose
+/// Account Setup rollup reached all-succeeded reconciles to Succeeded; one that finished
+/// Device Setup but whose user phase never completed is AwaitingUser (within grace) then
+/// Incomplete; and a session silent before Device Setup with no explicit failure is Incomplete
+/// — never Failed without an explicit failure signal.
+/// </summary>
+public class EnrollmentTimeoutClassifierTests
+{
+    private static readonly DateTime Start = new(2026, 7, 6, 15, 0, 0, DateTimeKind.Utc);
+
+    private static EnrollmentEvent Evt(string type, string? message = null) => new()
+    {
+        EventType = type,
+        Timestamp = Start,
+        Source = "test",
+        Message = message ?? type,
+    };
+
+    private static EnrollmentEvent Esp(string message) => Evt("esp_provisioning_status", message);
+
+    private const string DeviceSetup44 = "ESP provisioning status: DeviceSetup — 4 of 4 subcategories completed";
+    private const string DeviceSetupFallback =
+        "ESP provisioning status: DeviceSetup — all 4 subcategories succeeded but categorySucceeded was not confirmed by Windows — treating as complete (fallback after 30s)";
+    private const string AccountSetup05 = "ESP provisioning status: AccountSetup — 0 of 5 subcategories completed";
+    private const string AccountSetup15 = "ESP provisioning status: AccountSetup — 1 of 5 subcategories completed";
+    private const string AccountSetup55 = "ESP provisioning status: AccountSetup — 5 of 5 subcategories completed";
+    private const string AccountSetupFallback =
+        "ESP provisioning status: AccountSetup — all 5 subcategories succeeded but categorySucceeded was not confirmed by Windows — treating as complete (fallback after 30s)";
+
+    // -------- ExtractRollup --------
+
+    [Fact]
+    public void ExtractRollup_empty_is_all_false()
+    {
+        var r = EnrollmentTimeoutClassifier.ExtractRollup(null);
+        Assert.False(r.DeviceSetupAllSucceeded);
+        Assert.False(r.AccountSetupAllSucceeded);
+        Assert.Equal(0, r.AccountSetupSucceededCount);
+        Assert.False(r.HasExplicitFailure);
+        Assert.False(r.HasTerminalComplete);
+    }
+
+    [Fact]
+    public void ExtractRollup_reads_device_and_account_rollups()
+    {
+        var r = EnrollmentTimeoutClassifier.ExtractRollup(new[]
+        {
+            Esp(DeviceSetup44), Esp(AccountSetup05), Esp(AccountSetup15),
+        });
+        Assert.True(r.DeviceSetupAllSucceeded);
+        Assert.Equal(1, r.AccountSetupSucceededCount);   // strongest observation wins
+        Assert.Equal(5, r.AccountSetupTotal);
+        Assert.False(r.AccountSetupAllSucceeded);
+    }
+
+    [Fact]
+    public void ExtractRollup_account_5of5_is_all_succeeded()
+    {
+        var r = EnrollmentTimeoutClassifier.ExtractRollup(new[] { Esp(DeviceSetup44), Esp(AccountSetup55) });
+        Assert.True(r.AccountSetupAllSucceeded);
+        Assert.Equal(5, r.AccountSetupSucceededCount);
+    }
+
+    [Fact]
+    public void ExtractRollup_honours_fallback_complete_messages()
+    {
+        var r = EnrollmentTimeoutClassifier.ExtractRollup(new[] { Esp(DeviceSetupFallback), Esp(AccountSetupFallback) });
+        Assert.True(r.DeviceSetupAllSucceeded);
+        Assert.True(r.AccountSetupAllSucceeded);
+    }
+
+    [Fact]
+    public void ExtractRollup_detects_failure_and_complete_events()
+    {
+        Assert.True(EnrollmentTimeoutClassifier.ExtractRollup(new[] { Evt("enrollment_failed") }).HasExplicitFailure);
+        Assert.True(EnrollmentTimeoutClassifier.ExtractRollup(new[] { Evt("esp_failure") }).HasExplicitFailure);
+        Assert.True(EnrollmentTimeoutClassifier.ExtractRollup(new[] { Evt("enrollment_complete") }).HasTerminalComplete);
+        Assert.True(EnrollmentTimeoutClassifier.ExtractRollup(new[] { Evt("whiteglove_complete") }).HasTerminalComplete);
+    }
+
+    // -------- ClassifyTimedOutSession --------
+
+    private static (SessionStatus, string) Classify(IReadOnlyList<EnrollmentEvent> events, double hoursSinceStart = 6, int grace = 72)
+    {
+        var rollup = EnrollmentTimeoutClassifier.ExtractRollup(events);
+        var now = Start.AddHours(hoursSinceStart);
+        return EnrollmentTimeoutClassifier.ClassifyTimedOutSession(rollup, Start, now, grace);
+    }
+
+    [Fact]
+    public void Classify_explicit_failure_is_Failed()
+    {
+        var (status, _) = Classify(new[] { Esp(DeviceSetup44), Evt("enrollment_failed") });
+        Assert.Equal(SessionStatus.Failed, status);
+    }
+
+    [Fact]
+    public void Classify_account_setup_complete_reconciles_to_Succeeded()
+    {
+        var (status, _) = Classify(new[] { Esp(DeviceSetup44), Esp(AccountSetup55) });
+        Assert.Equal(SessionStatus.Succeeded, status);
+    }
+
+    [Fact]
+    public void Classify_enrollment_complete_reconciles_to_Succeeded()
+    {
+        var (status, _) = Classify(new[] { Esp(DeviceSetup44), Esp(AccountSetup05), Evt("enrollment_complete") });
+        Assert.Equal(SessionStatus.Succeeded, status);
+    }
+
+    [Fact]
+    public void Classify_device_provisioned_user_phase_pending_within_grace_is_AwaitingUser()
+    {
+        // The dominant crcins.com case: DeviceSetup 4/4, AccountSetup 0/5, silent, 6h in.
+        var (status, reason) = Classify(new[] { Esp(DeviceSetup44), Esp(AccountSetup05) }, hoursSinceStart: 6);
+        Assert.Equal(SessionStatus.AwaitingUser, status);
+        Assert.Contains("Device Setup completed", reason);
+    }
+
+    [Fact]
+    public void Classify_device_provisioned_after_grace_is_Incomplete()
+    {
+        var (status, _) = Classify(new[] { Esp(DeviceSetup44), Esp(AccountSetup05) }, hoursSinceStart: 80, grace: 72);
+        Assert.Equal(SessionStatus.Incomplete, status);
+    }
+
+    [Fact]
+    public void Classify_silent_before_device_setup_is_Incomplete_not_Failed()
+    {
+        // No DeviceSetup all-succeeded, no failure event → Incomplete (we don't know), not Failed.
+        var (status, _) = Classify(new[] { Evt("agent_started"), Esp("ESP provisioning status: DeviceSetup — 3 of 4 subcategories completed") });
+        Assert.Equal(SessionStatus.Incomplete, status);
+    }
+
+    [Fact]
+    public void Classify_never_returns_Failed_without_explicit_failure()
+    {
+        // Guard the core invariant across a spread of non-failure inputs.
+        foreach (var events in new[]
+        {
+            new[] { Esp(DeviceSetup44), Esp(AccountSetup05) },
+            new[] { Esp(DeviceSetupFallback) },
+            new[] { Evt("agent_started") },
+        })
+        {
+            var (status, _) = Classify(events);
+            Assert.NotEqual(SessionStatus.Failed, status);
+        }
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions.Tests/EnrollmentTimeoutClassifierTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/EnrollmentTimeoutClassifierTests.cs
@@ -169,6 +169,7 @@ public class EnrollmentTimeoutClassifierTests
     [InlineData(0, null, 51)]    // 0 override = auto-derive
     [InlineData(0, 48, 51)]      // explicit agent cap = default
     [InlineData(0, 96, 99)]      // bigger agent cap → grace follows (96 + 3)
+    [InlineData(0, 36, 51)]      // override BELOW the real agent default is clamped up to 48 (agent isn't wired yet)
     [InlineData(0, 0, 51)]       // agent cap 0/invalid → fall back to default 48
     [InlineData(90, 48, 90)]     // override ABOVE the floor wins
     [InlineData(30, 48, 51)]     // override BELOW the floor is clamped up to the floor

--- a/src/Backend/AutopilotMonitor.Functions.Tests/EnrollmentTimeoutClassifierTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/EnrollmentTimeoutClassifierTests.cs
@@ -141,6 +141,34 @@ public class EnrollmentTimeoutClassifierTests
         Assert.Equal(SessionStatus.Incomplete, status);
     }
 
+    // -------- ResolveGraceHours --------
+
+    [Theory]
+    [InlineData(null, null, 60)] // defaults: 48 + 12
+    [InlineData(0, null, 60)]    // 0 override = auto-derive
+    [InlineData(0, 48, 60)]      // explicit agent cap = default
+    [InlineData(0, 96, 108)]     // bigger agent cap → grace follows (96 + 12)
+    [InlineData(0, 0, 60)]       // agent cap 0/invalid → fall back to default 48
+    [InlineData(90, 48, 90)]     // override ABOVE the floor wins
+    [InlineData(30, 48, 60)]     // override BELOW the floor is clamped up to the floor
+    public void ResolveGraceHours_floors_at_agent_cap_plus_buffer(int? configured, int? absoluteMax, int expected)
+    {
+        Assert.Equal(expected, EnrollmentTimeoutClassifier.ResolveGraceHours(configured, absoluteMax));
+    }
+
+    [Fact]
+    public void ResolveGraceHours_never_below_agent_absolute_cap()
+    {
+        // Property: whatever the inputs, the grace is at least the agent's absolute cap, so the backend
+        // never terminalizes Incomplete while the agent could still legitimately be enrolling.
+        foreach (var absMax in new int?[] { null, 6, 48, 72, 96 })
+        {
+            var cap = absMax.GetValueOrDefault(EnrollmentTimeoutClassifier.DefaultAbsoluteMaxSessionHours);
+            var grace = EnrollmentTimeoutClassifier.ResolveGraceHours(0, absMax);
+            Assert.True(grace >= cap, $"grace {grace} must be >= agent cap {cap}");
+        }
+    }
+
     [Fact]
     public void Classify_never_returns_Failed_without_explicit_failure()
     {

--- a/src/Backend/AutopilotMonitor.Functions.Tests/ReportAgentErrorFunctionTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/ReportAgentErrorFunctionTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using AutopilotMonitor.Functions.Functions.Ingest;
+using AutopilotMonitor.Shared.Models;
+
+namespace AutopilotMonitor.Functions.Tests;
+
+/// <summary>
+/// Pins <see cref="ReportAgentErrorFunction.BuildAgentEmergencyBreakEvent"/> — the backend-materialized
+/// timeline event synthesized from the agent's best-effort 48h emergency-break report
+/// (docs/design/enrollment-status-reclassification.md). The load-bearing bits are the Sequence assignment
+/// (must sort AFTER the session's last event) and that it is a Warning, non-terminal marker — the timeout
+/// classifier, not this event, decides the real verdict.
+/// </summary>
+public class ReportAgentErrorFunctionTests
+{
+    private const string TenantId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    private const string SessionId = "b2c3d4e5-f6a7-8901-bcde-f12345678901";
+
+    private static AgentErrorReport Report(DateTime ts, string? message = null) => new()
+    {
+        SessionId = SessionId,
+        TenantId = TenantId,
+        ErrorType = AgentErrorType.SessionAgeEmergencyBreak,
+        Message = message!,
+        AgentVersion = "2.0.1236",
+        Timestamp = ts,
+    };
+
+    private static readonly DateTime Now = new(2026, 7, 8, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void Sequence_is_one_past_the_session_max()
+    {
+        var existing = new List<EnrollmentEvent>
+        {
+            new() { Sequence = 5 }, new() { Sequence = 88 }, new() { Sequence = 12 },
+        };
+        var evt = ReportAgentErrorFunction.BuildAgentEmergencyBreakEvent(
+            Report(Now.AddMinutes(-1)), TenantId, existing, Now);
+        Assert.Equal(89, evt.Sequence);
+    }
+
+    [Fact]
+    public void Sequence_is_one_when_no_prior_events()
+    {
+        Assert.Equal(1, ReportAgentErrorFunction.BuildAgentEmergencyBreakEvent(
+            Report(Now), TenantId, new List<EnrollmentEvent>(), Now).Sequence);
+    }
+
+    [Fact]
+    public void Shape_is_warning_non_terminal_agent_break()
+    {
+        var evt = ReportAgentErrorFunction.BuildAgentEmergencyBreakEvent(Report(Now), TenantId, null!, Now);
+
+        Assert.Equal("agent_emergency_break", evt.EventType);
+        Assert.Equal(AutopilotMonitor.Shared.Constants.EventTypes.AgentEmergencyBreak, evt.EventType);
+        Assert.Equal(EventSeverity.Warning, evt.Severity);
+        Assert.Equal(EnrollmentPhase.Unknown, evt.Phase);
+        Assert.Equal(TenantId, evt.TenantId);
+        Assert.Equal(SessionId, evt.SessionId);
+        Assert.Equal("emergency_channel", evt.Data["source"]);
+    }
+
+    [Fact]
+    public void Uses_agent_break_timestamp_when_valid_else_receipt_time()
+    {
+        var breakTime = Now.AddHours(-2);
+        Assert.Equal(breakTime, ReportAgentErrorFunction.BuildAgentEmergencyBreakEvent(
+            Report(breakTime), TenantId, null!, Now).Timestamp);
+
+        // Bogus/default timestamp → fall back to receipt time (now).
+        Assert.Equal(Now, ReportAgentErrorFunction.BuildAgentEmergencyBreakEvent(
+            Report(default), TenantId, null!, Now).Timestamp);
+    }
+
+    [Fact]
+    public void Falls_back_to_default_message_when_report_message_blank()
+    {
+        var evt = ReportAgentErrorFunction.BuildAgentEmergencyBreakEvent(Report(Now, message: ""), TenantId, null!, Now);
+        Assert.Contains("emergency break", evt.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions.Tests/SessionStatusBucketsTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/SessionStatusBucketsTests.cs
@@ -1,0 +1,58 @@
+using AutopilotMonitor.Functions.Helpers;
+
+namespace AutopilotMonitor.Functions.Tests;
+
+/// <summary>
+/// Pins the third-state stats bucketing (docs/design/enrollment-status-reclassification.md):
+/// AwaitingUser and Incomplete get their own buckets instead of hiding in Other, and the buckets
+/// always reconcile to Total by construction — so a session in either state can never be silently
+/// miscounted as a failure.
+/// </summary>
+public class SessionStatusBucketsTests
+{
+    private static SessionStatusBuckets Tally(params string[] statuses)
+    {
+        var b = default(SessionStatusBuckets);
+        foreach (var s in statuses) b = b.Add(s);
+        return b;
+    }
+
+    [Fact]
+    public void Incomplete_and_AwaitingUser_get_their_own_buckets_not_Other()
+    {
+        var b = Tally("Incomplete", "Incomplete", "AwaitingUser");
+        Assert.Equal(2, b.Incomplete);
+        Assert.Equal(1, b.AwaitingUser);
+        Assert.Equal(0, b.Other);
+    }
+
+    [Fact]
+    public void Unknown_status_still_lands_in_Other()
+    {
+        var b = Tally("Succeeded", "SomethingWeird");
+        Assert.Equal(1, b.Succeeded);
+        Assert.Equal(1, b.Other);
+    }
+
+    [Fact]
+    public void Buckets_always_reconcile_to_total()
+    {
+        var b = Tally("Succeeded", "Failed", "Incomplete", "AwaitingUser", "InProgress", "Pending", "Stalled", "weird");
+        Assert.Equal(8, b.Total);
+        Assert.Equal(b.Total,
+            b.Succeeded + b.Failed + b.Incomplete + b.AwaitingUser + b.InProgress + b.Pending + b.Stalled + b.Other);
+    }
+
+    [Fact]
+    public void Failure_rate_denominator_is_terminal_only_excluding_incomplete()
+    {
+        // 1 succeeded, 1 failed, 8 incomplete (the crcins shape). Honest rate = 1/(1+1) = 50%,
+        // NOT 1/10 = 10% (Incomplete must not dilute) and NOT counting Incomplete as failures.
+        var b = Tally("Succeeded", "Failed", "Incomplete", "Incomplete", "Incomplete", "Incomplete",
+                      "Incomplete", "Incomplete", "Incomplete", "Incomplete");
+        var terminal = b.Succeeded + b.Failed;
+        var failureRate = terminal > 0 ? (double)b.Failed / terminal * 100 : 0;
+        Assert.Equal(50.0, failureRate);
+        Assert.Equal(8, b.Incomplete);
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions.Tests/SessionStatusTransitionTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/SessionStatusTransitionTests.cs
@@ -1,0 +1,63 @@
+using AutopilotMonitor.Functions.Services;
+using AutopilotMonitor.Shared.Models;
+
+namespace AutopilotMonitor.Functions.Tests;
+
+/// <summary>
+/// Pins the terminal/reconcile transition matrix (docs/design/enrollment-status-reclassification.md):
+/// a genuine completion may upgrade a prior Failed/Incomplete/AwaitingUser verdict (late reconcile),
+/// while the silent-terminal verdicts never overwrite an existing terminal. This is the pure core of
+/// PR3 — the reconcile that lets a device which completed after a sweep-timeout heal to Succeeded.
+/// </summary>
+public class SessionStatusTransitionTests
+{
+    // ---- Succeeded may UPGRADE any non-Succeeded state (reconcile) ----
+    [Theory]
+    [InlineData("Failed", true)]
+    [InlineData("Incomplete", true)]
+    [InlineData("AwaitingUser", true)]
+    [InlineData("InProgress", true)]
+    [InlineData("Stalled", true)]
+    [InlineData("Succeeded", false)] // idempotent — already succeeded
+    public void Succeeded_upgrades_everything_except_an_existing_success(string existing, bool allowed)
+    {
+        Assert.Equal(allowed, TableStorageService.IsTerminalTransitionAllowed(existing, SessionStatus.Succeeded));
+    }
+
+    // ---- Failed / Incomplete never overwrite an existing terminal ----
+    [Theory]
+    [InlineData("Succeeded", false)]
+    [InlineData("Failed", false)]
+    [InlineData("Incomplete", false)]
+    [InlineData("AwaitingUser", true)]  // AwaitingUser is non-terminal
+    [InlineData("InProgress", true)]
+    [InlineData("Stalled", true)]
+    public void Failed_and_Incomplete_never_overwrite_a_terminal(string existing, bool allowed)
+    {
+        Assert.Equal(allowed, TableStorageService.IsTerminalTransitionAllowed(existing, SessionStatus.Failed));
+        Assert.Equal(allowed, TableStorageService.IsTerminalTransitionAllowed(existing, SessionStatus.Incomplete));
+    }
+
+    // ---- AwaitingUser never regresses a terminal ----
+    [Theory]
+    [InlineData("Succeeded", false)]
+    [InlineData("Failed", false)]
+    [InlineData("Incomplete", false)]
+    [InlineData("InProgress", true)]
+    [InlineData("Stalled", true)]
+    public void AwaitingUser_never_regresses_a_terminal(string existing, bool allowed)
+    {
+        Assert.Equal(allowed, TableStorageService.IsTerminalTransitionAllowed(existing, SessionStatus.AwaitingUser));
+    }
+
+    // ---- Non-terminal incoming is governed by downstream guards, allowed here ----
+    [Theory]
+    [InlineData(SessionStatus.InProgress)]
+    [InlineData(SessionStatus.Stalled)]
+    [InlineData(SessionStatus.Pending)]
+    public void Non_terminal_incoming_is_allowed_here(SessionStatus incoming)
+    {
+        Assert.True(TableStorageService.IsTerminalTransitionAllowed("Failed", incoming));
+        Assert.True(TableStorageService.IsTerminalTransitionAllowed("Succeeded", incoming));
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions.Tests/TenantConfigTableSerializationTests.cs
+++ b/src/Backend/AutopilotMonitor.Functions.Tests/TenantConfigTableSerializationTests.cs
@@ -85,4 +85,38 @@ public class TenantConfigTableSerializationTests
         var entity = new TableEntity(TenantId, "config") { { "DomainName", "fabrikam.com" } };
         Assert.Equal("free", TableConfigRepository.ConvertFromTenantTableEntity(entity).PlanTier);
     }
+
+    [Fact]
+    public void Roundtrip_SessionGraceAndAbsoluteCapOverrides_SurviveStoreAndMap()
+    {
+        // These feed EnrollmentTimeoutClassifier via MaintenanceService — a tenant override that
+        // doesn't roundtrip means the sweep silently falls back to auto-derive/defaults.
+        var config = new TenantConfiguration
+        {
+            TenantId = TenantId,
+            DomainName = "contoso.com",
+            UpdatedBy = "admin@contoso.com",
+            SessionGraceHours = 72,
+            AbsoluteMaxSessionHours = 36
+        };
+
+        var mapped = TableConfigRepository.ConvertFromTenantTableEntity(
+            TableConfigRepository.ConvertToTenantTableEntity(config));
+
+        Assert.Equal(72, mapped.SessionGraceHours);
+        Assert.Equal(36, mapped.AbsoluteMaxSessionHours);
+    }
+
+    [Fact]
+    public void Map_LegacyRow_WithoutTimeoutColumns_DefaultsToAutoDerive()
+    {
+        // A row written before the reclassification columns existed: grace reads back as 0
+        // (auto-derive) and the absolute-cap override stays null (agent default 48h applies).
+        var entity = new TableEntity(TenantId, "config") { { "DomainName", "fabrikam.com" } };
+
+        var mapped = TableConfigRepository.ConvertFromTenantTableEntity(entity);
+
+        Assert.Equal(0, mapped.SessionGraceHours);
+        Assert.Null(mapped.AbsoluteMaxSessionHours);
+    }
 }

--- a/src/Backend/AutopilotMonitor.Functions/DataAccess/TableStorage/TableConfigRepository.cs
+++ b/src/Backend/AutopilotMonitor.Functions/DataAccess/TableStorage/TableConfigRepository.cs
@@ -349,6 +349,8 @@ namespace AutopilotMonitor.Functions.DataAccess.TableStorage
                 { "AllowInsecureAgentRequests", config.AllowInsecureAgentRequests },
                 { "DataRetentionDays", config.DataRetentionDays },
                 { "SessionTimeoutHours", config.SessionTimeoutHours },
+                { "SessionGraceHours", config.SessionGraceHours },
+                { "AbsoluteMaxSessionHours", config.AbsoluteMaxSessionHours },
                 { "MaxNdjsonPayloadSizeMB", config.MaxNdjsonPayloadSizeMB },
                 { "EnablePerformanceCollector", config.EnablePerformanceCollector },
                 { "PerformanceCollectorIntervalSeconds", config.PerformanceCollectorIntervalSeconds },
@@ -442,6 +444,12 @@ namespace AutopilotMonitor.Functions.DataAccess.TableStorage
                 AllowInsecureAgentRequests = entity.GetBoolean("AllowInsecureAgentRequests") ?? false,
                 DataRetentionDays = entity.GetInt32("DataRetentionDays") ?? 90,
                 SessionTimeoutHours = entity.GetInt32("SessionTimeoutHours") ?? 5,
+                // 0 (default) = auto-derive grace from the agent's absolute cap; legacy rows lacking
+                // the column read back as 0, preserving the auto-derive behaviour.
+                SessionGraceHours = entity.GetInt32("SessionGraceHours") ?? 0,
+                // null = agent default (48); nullable so an unset override never masquerades as an
+                // explicit value in EnrollmentTimeoutClassifier.ResolveGraceHours.
+                AbsoluteMaxSessionHours = entity.GetInt32("AbsoluteMaxSessionHours"),
                 MaxNdjsonPayloadSizeMB = entity.GetInt32("MaxNdjsonPayloadSizeMB") ?? 5,
                 EnablePerformanceCollector = entity.GetBoolean("EnablePerformanceCollector") ?? false,
                 PerformanceCollectorIntervalSeconds = entity.GetInt32("PerformanceCollectorIntervalSeconds") ?? 30,

--- a/src/Backend/AutopilotMonitor.Functions/DataAccess/TableStorage/TableSessionRepository.cs
+++ b/src/Backend/AutopilotMonitor.Functions/DataAccess/TableStorage/TableSessionRepository.cs
@@ -72,13 +72,15 @@ namespace AutopilotMonitor.Functions.DataAccess.TableStorage
 
             // Reconcile the authoritative EventCount + RebootCount whenever a session actually
             // transitions to a terminal state through ANY caller — ingest, admin mark
-            // (Mark{Succeeded,Failed}Function), maintenance timeout, or rule-engine fail. This is
-            // the single seam they all funnel through, so the stored counts stay correct even on
-            // the non-ingest terminal paths that never run a terminal ingest batch. The ingest
-            // path additionally reconciles after its event-count increment (covering
-            // already-terminal batch replays, where this call's transitioned=false
-            // short-circuits). Idempotent + fail-soft, so the redundancy is cheap.
-            if (transitioned && (status == SessionStatus.Succeeded || status == SessionStatus.Failed))
+            // (Mark{Succeeded,Failed}Function), maintenance timeout (Failed OR Incomplete), or
+            // rule-engine fail. This is the single seam they all funnel through, so the stored
+            // counts stay correct even on the non-ingest terminal paths that never run a terminal
+            // ingest batch. The ingest path additionally reconciles after its event-count increment
+            // (covering already-terminal batch replays, where this call's transitioned=false
+            // short-circuits). Incomplete is terminal too, so it must reconcile like Failed —
+            // otherwise a swept-Incomplete session keeps whatever stale live count it had.
+            // Idempotent + fail-soft, so the redundancy is cheap.
+            if (transitioned && (status == SessionStatus.Succeeded || status == SessionStatus.Failed || status == SessionStatus.Incomplete))
                 await _storage.ReconcileSessionCountersAsync(tenantId, sessionId);
 
             return transitioned;

--- a/src/Backend/AutopilotMonitor.Functions/Functions/Ingest/ReportAgentErrorFunction.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Functions/Ingest/ReportAgentErrorFunction.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text.Json;
 using AutopilotMonitor.Functions.Security;
 using AutopilotMonitor.Functions.Services;
+using AutopilotMonitor.Shared;
+using AutopilotMonitor.Shared.DataAccess;
 using AutopilotMonitor.Shared.Models;
 using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Functions.Worker;
@@ -33,6 +36,7 @@ namespace AutopilotMonitor.Functions.Functions.Ingest
         private readonly DeviceAssociationValidator _deviceAssociationValidator;
         private readonly TelemetryClient _telemetryClient;
         private readonly BootstrapSessionService _bootstrapSessionService;
+        private readonly ISessionRepository _sessionRepo;
 
         public ReportAgentErrorFunction(
             ILogger<ReportAgentErrorFunction> logger,
@@ -43,7 +47,8 @@ namespace AutopilotMonitor.Functions.Functions.Ingest
             CorporateIdentifierValidator corporateIdentifierValidator,
             DeviceAssociationValidator deviceAssociationValidator,
             TelemetryClient telemetryClient,
-            BootstrapSessionService bootstrapSessionService)
+            BootstrapSessionService bootstrapSessionService,
+            ISessionRepository sessionRepo)
         {
             _logger = logger;
             _configService = configService;
@@ -54,6 +59,7 @@ namespace AutopilotMonitor.Functions.Functions.Ingest
             _deviceAssociationValidator = deviceAssociationValidator;
             _telemetryClient = telemetryClient;
             _bootstrapSessionService = bootstrapSessionService;
+            _sessionRepo = sessionRepo;
         }
 
         [Function("ReportAgentError")]
@@ -163,7 +169,77 @@ namespace AutopilotMonitor.Functions.Functions.Ingest
                 ["AgentTimestamp"] = report.Timestamp.ToString("O"),
             });
 
+            // Materialize the agent's silent 48h emergency break as a timeline event so it shows in the
+            // session and the timeout classifier can see it (docs/design/enrollment-status-reclassification.md).
+            // Best-effort — a failure here must never turn the always-200 emergency channel into a retry loop.
+            if (report.ErrorType == AgentErrorType.SessionAgeEmergencyBreak
+                && !string.IsNullOrEmpty(report.SessionId))
+            {
+                try
+                {
+                    var existing = await _sessionRepo.GetSessionEventsAsync(tenantId, report.SessionId, maxResults: 1000);
+                    // Idempotency: the agent's emergency channel can send up to a few reports per session;
+                    // only ever materialize one timeline event.
+                    var alreadyMaterialized = existing.Any(e =>
+                        string.Equals(e.EventType, Constants.EventTypes.AgentEmergencyBreak, StringComparison.OrdinalIgnoreCase));
+                    if (!alreadyMaterialized)
+                    {
+                        var evt = BuildAgentEmergencyBreakEvent(report, tenantId, existing, DateTime.UtcNow);
+                        await _sessionRepo.StoreEventsBatchAsync(new List<EnrollmentEvent> { evt });
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "ReportAgentError: failed to materialize agent_emergency_break event for session {SessionId}", report.SessionId);
+                }
+            }
+
             return req.CreateResponse(HttpStatusCode.OK);
+        }
+
+        /// <summary>
+        /// Builds the backend-materialized <c>agent_emergency_break</c> timeline event from the agent's
+        /// best-effort emergency report. Static + pure (analog to
+        /// <see cref="Services.MaintenanceService.BuildSessionTimeoutEvent"/>) so the field shape and the
+        /// Sequence assignment (one past the session's last event, so it sorts LAST) are unit-testable.
+        /// Severity is Warning, not Error: the emergency break means "the agent gave up monitoring at its
+        /// absolute age cap", NOT that the enrollment failed — the timeout classifier decides the real
+        /// verdict from the ESP rollup.
+        /// </summary>
+        internal static EnrollmentEvent BuildAgentEmergencyBreakEvent(
+            AgentErrorReport report, string tenantId, IReadOnlyList<EnrollmentEvent> existingEvents, DateTime nowUtc)
+        {
+            var maxSequence = existingEvents != null && existingEvents.Count > 0
+                ? existingEvents.Max(e => e.Sequence)
+                : 0L;
+
+            // Prefer the agent's break timestamp for an accurate timeline; fall back to receipt time when
+            // the report carries no (or a clearly bogus) timestamp.
+            var breakAt = report.Timestamp > new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+                ? report.Timestamp.ToUniversalTime()
+                : nowUtc;
+
+            return new EnrollmentEvent
+            {
+                TenantId = tenantId,
+                SessionId = report.SessionId,
+                EventType = Constants.EventTypes.AgentEmergencyBreak,
+                Source = "System.EmergencyChannel",
+                Severity = EventSeverity.Warning,
+                Phase = EnrollmentPhase.Unknown,
+                Timestamp = breakAt,
+                Sequence = maxSequence + 1,
+                Message = string.IsNullOrWhiteSpace(report.Message)
+                    ? "Agent absolute session-age emergency break fired — agent cleaned up and exited"
+                    : report.Message,
+                Data = new Dictionary<string, object>
+                {
+                    ["source"] = "emergency_channel",
+                    ["agentVersion"] = report.AgentVersion ?? string.Empty,
+                    ["reportedAtUtc"] = report.Timestamp.ToString("o"),
+                },
+            };
         }
     }
 }

--- a/src/Backend/AutopilotMonitor.Functions/Helpers/MetricsMath.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Helpers/MetricsMath.cs
@@ -315,7 +315,8 @@ public static class MetricsMath
 /// their own buckets, and any unrecognised status (incl. Unknown) lands in <see cref="Other"/>.
 /// </summary>
 public readonly record struct SessionStatusBuckets(
-    int Total, int Succeeded, int Failed, int InProgress, int Pending, int Stalled, int Other)
+    int Total, int Succeeded, int Failed, int InProgress, int Pending, int Stalled,
+    int AwaitingUser, int Incomplete, int Other)
 {
     /// <summary>Returns a new tally with <paramref name="status"/> folded in.</summary>
     public SessionStatusBuckets Add(string? status)
@@ -326,7 +327,11 @@ public readonly record struct SessionStatusBuckets(
         var inProgress = InProgress + (status == "InProgress" ? 1 : 0);
         var pending = Pending + (status == "Pending" ? 1 : 0);
         var stalled = Stalled + (status == "Stalled" ? 1 : 0);
-        var other = total - (succeeded + failed + inProgress + pending + stalled);
-        return new SessionStatusBuckets(total, succeeded, failed, inProgress, pending, stalled, other);
+        // AwaitingUser (non-terminal, Device Setup done) and Incomplete (terminal, non-failure) get
+        // their own buckets so they no longer hide in Other and never inflate the failure count.
+        var awaitingUser = AwaitingUser + (status == "AwaitingUser" ? 1 : 0);
+        var incomplete = Incomplete + (status == "Incomplete" ? 1 : 0);
+        var other = total - (succeeded + failed + inProgress + pending + stalled + awaitingUser + incomplete);
+        return new SessionStatusBuckets(total, succeeded, failed, inProgress, pending, stalled, awaitingUser, incomplete, other);
     }
 }

--- a/src/Backend/AutopilotMonitor.Functions/Helpers/MetricsMath.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Helpers/MetricsMath.cs
@@ -99,7 +99,7 @@ public static class MetricsMath
     /// </summary>
     public static FleetHealthMetrics BuildFleetHealthPayload(IReadOnlyList<SessionSummary> sessions, int days)
     {
-        int succeeded = 0, failed = 0, inProgress = 0;
+        int succeeded = 0, failed = 0, inProgress = 0, incomplete = 0;
         long completedDurationSeconds = 0;
         int completedWithDurationCount = 0;
 
@@ -110,6 +110,7 @@ public static class MetricsMath
                 case SessionStatus.Succeeded: succeeded++; break;
                 case SessionStatus.Failed: failed++; break;
                 case SessionStatus.InProgress: inProgress++; break;
+                case SessionStatus.Incomplete: incomplete++; break;
             }
 
             if (s.Status != SessionStatus.InProgress && s.DurationSeconds is int d && d > 0)
@@ -126,6 +127,7 @@ public static class MetricsMath
             Succeeded = succeeded,
             Failed = failed,
             InProgress = inProgress,
+            Incomplete = incomplete,
             SuccessRate = total > 0 ? Math.Round((double)succeeded / total * 100, 1) : 0,
             AvgDurationMinutes = completedWithDurationCount > 0
                 ? (int)Math.Round((double)completedDurationSeconds / completedWithDurationCount / 60.0, MidpointRounding.AwayFromZero)

--- a/src/Backend/AutopilotMonitor.Functions/Services/EnrollmentTimeoutClassifier.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/EnrollmentTimeoutClassifier.cs
@@ -51,7 +51,14 @@ namespace AutopilotMonitor.Functions.Services
         public static int ResolveGraceHours(int? configuredGraceHours, int? absoluteMaxSessionHours, int bufferHours = DefaultGraceBufferHours)
         {
             var absMax = absoluteMaxSessionHours.GetValueOrDefault(DefaultAbsoluteMaxSessionHours);
-            if (absMax <= 0) absMax = DefaultAbsoluteMaxSessionHours;
+            // The agent does NOT yet honor a per-tenant AbsoluteMaxSessionHours override (wiring it
+            // down to the agent config response is a follow-up — see TenantConfiguration.AbsoluteMaxSessionHours),
+            // so the agent always runs to at least the real runtime default (48h). The silence-based
+            // grace floor is only safe if it assumes the agent could still be alive up to that real cap:
+            // a lower/unset override must therefore only ever RAISE the assumed cap, never drag the floor
+            // below the agent's actual runtime — which would terminalize a still-running session as
+            // Incomplete before its emergency break even fires. Clamp accordingly (also covers 0/negative).
+            absMax = Math.Max(absMax, DefaultAbsoluteMaxSessionHours);
             var floor = absMax + Math.Max(0, bufferHours);
             var configured = configuredGraceHours.GetValueOrDefault(0);
             return Math.Max(floor, configured);

--- a/src/Backend/AutopilotMonitor.Functions/Services/EnrollmentTimeoutClassifier.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/EnrollmentTimeoutClassifier.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using AutopilotMonitor.Shared.Models;
+
+namespace AutopilotMonitor.Functions.Services
+{
+    /// <summary>
+    /// Pure classification of a session that the maintenance sweep is about to terminalize
+    /// (docs/design/enrollment-status-reclassification.md). Instead of hard-coding every
+    /// silent session to <see cref="SessionStatus.Failed"/>, we read the ESP subcategory
+    /// rollup the agent already emits and decide the honest target state.
+    ///
+    /// Why parse the <c>esp_provisioning_status</c> <b>Message</b> rather than the Data
+    /// object: Windows never sets the category-level <c>categorySucceeded</c> boolean (it is
+    /// perpetually <c>"in_progress"</c> even at DeviceSetup 4/4 and AccountSetup 5/5), so the
+    /// authoritative rollup is the per-category "N of M subcategories completed" line — which
+    /// the agent authors in one place (ProvisioningStatusTracker) and which was validated at
+    /// scale against real crcins.com data. The 30s "all subcategories succeeded but
+    /// categorySucceeded was not confirmed … treating as complete" fallback line is treated
+    /// as all-succeeded for its category.
+    /// </summary>
+    public static class EnrollmentTimeoutClassifier
+    {
+        /// <summary>ESP category names as they appear in the provisioning-status message.</summary>
+        private const string DeviceSetup = "DeviceSetup";
+        private const string AccountSetup = "AccountSetup";
+
+        // "ESP provisioning status: AccountSetup — 5 of 5 subcategories completed"
+        private static readonly Regex RollupRegex = new(
+            @"ESP provisioning status:\s*(?<cat>DeviceSetup|AccountSetup)\s*[—-]\s*(?<n>\d+)\s+of\s+(?<m>\d+)\s+subcategories completed",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        // "ESP provisioning status: DeviceSetup — all 4 subcategories succeeded but
+        //  categorySucceeded was not confirmed by Windows — treating as complete (fallback after 30s)"
+        private static readonly Regex FallbackCompleteRegex = new(
+            @"ESP provisioning status:\s*(?<cat>DeviceSetup|AccountSetup)\s*[—-]\s*all\s+(?<m>\d+)\s+subcategories succeeded.*treating as complete",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        /// <summary>
+        /// Distilled ESP lifecycle facts extracted from a session's event stream — the inputs
+        /// to <see cref="ClassifyTimedOutSession"/>. Also embedded into the failure snapshot so
+        /// operators see the same evidence the classifier used.
+        /// </summary>
+        public readonly record struct EspProvisioningRollup(
+            bool DeviceSetupAllSucceeded,
+            int AccountSetupSucceededCount,
+            int AccountSetupTotal,
+            bool AccountSetupAllSucceeded,
+            bool HasExplicitFailure,
+            bool HasTerminalComplete);
+
+        /// <summary>
+        /// Walk a session's events and distill the ESP rollup. Tolerant of missing/empty input
+        /// (returns an all-false rollup). Order-independent — takes the strongest observation
+        /// per category (highest AccountSetup completion count, any DeviceSetup all-succeeded).
+        /// </summary>
+        public static EspProvisioningRollup ExtractRollup(IReadOnlyList<EnrollmentEvent>? events)
+        {
+            if (events == null || events.Count == 0)
+                return default;
+
+            bool deviceAll = false;
+            int acctBestN = 0, acctBestM = 0;
+            bool acctFallbackAll = false;
+            bool hasFailure = false, hasComplete = false;
+
+            foreach (var evt in events)
+            {
+                var type = evt.EventType ?? string.Empty;
+
+                if (Eq(type, "enrollment_failed") || Eq(type, "esp_failure"))
+                    hasFailure = true;
+                else if (Eq(type, "enrollment_complete") || Eq(type, "whiteglove_complete"))
+                    hasComplete = true;
+
+                var msg = evt.Message;
+                if (string.IsNullOrEmpty(msg)) continue;
+
+                var fb = FallbackCompleteRegex.Match(msg);
+                if (fb.Success)
+                {
+                    if (Eq(fb.Groups["cat"].Value, DeviceSetup)) deviceAll = true;
+                    else if (Eq(fb.Groups["cat"].Value, AccountSetup)) acctFallbackAll = true;
+                    continue;
+                }
+
+                var m = RollupRegex.Match(msg);
+                if (!m.Success) continue;
+
+                var cat = m.Groups["cat"].Value;
+                var n = int.Parse(m.Groups["n"].Value);
+                var total = int.Parse(m.Groups["m"].Value);
+
+                if (Eq(cat, DeviceSetup))
+                {
+                    if (total > 0 && n >= total) deviceAll = true;
+                }
+                else if (Eq(cat, AccountSetup))
+                {
+                    // Keep the strongest AccountSetup observation (highest completion count).
+                    if (n > acctBestN) { acctBestN = n; acctBestM = total; }
+                }
+            }
+
+            var acctAll = acctFallbackAll || (acctBestM > 0 && acctBestN >= acctBestM);
+            return new EspProvisioningRollup(
+                DeviceSetupAllSucceeded: deviceAll,
+                AccountSetupSucceededCount: acctBestN,
+                AccountSetupTotal: acctBestM,
+                AccountSetupAllSucceeded: acctAll,
+                HasExplicitFailure: hasFailure,
+                HasTerminalComplete: hasComplete);
+        }
+
+        /// <summary>
+        /// Decide the honest terminal (or non-terminal) state for a timed-out session. See the
+        /// decision table in the design note. Returns the target status and a human-readable
+        /// reason for the Sessions row / operator UI.
+        /// </summary>
+        /// <param name="rollup">Facts from <see cref="ExtractRollup"/>.</param>
+        /// <param name="startedAtUtc">Session start (grace is measured from here).</param>
+        /// <param name="nowUtc">Sweep timestamp.</param>
+        /// <param name="graceHours">Grace window before AwaitingUser graduates to Incomplete.</param>
+        public static (SessionStatus Status, string Reason) ClassifyTimedOutSession(
+            EspProvisioningRollup rollup, DateTime startedAtUtc, DateTime nowUtc, int graceHours)
+        {
+            // 1. An explicit terminal failure event is a real failure (defensive — such a session
+            //    would normally already be terminal via ingest and not reach the sweep).
+            if (rollup.HasExplicitFailure)
+                return (SessionStatus.Failed, "Enrollment reported an explicit failure before timeout");
+
+            // 2. Account Setup fully succeeded (or a terminal completion event) → reconcile to success.
+            if (rollup.AccountSetupAllSucceeded || rollup.HasTerminalComplete)
+                return (SessionStatus.Succeeded,
+                    "Reconciled at timeout: Account Setup completed (all subcategories succeeded / enrollment_complete observed)");
+
+            // 3. Device Setup fully provisioned (device is AADJ + MDM-enrolled), user phase pending.
+            if (rollup.DeviceSetupAllSucceeded)
+            {
+                var elapsedHours = (nowUtc - startedAtUtc).TotalHours;
+                if (elapsedHours < graceHours)
+                {
+                    var acct = rollup.AccountSetupTotal > 0
+                        ? $" (Account Setup {rollup.AccountSetupSucceededCount}/{rollup.AccountSetupTotal})"
+                        : " (Account Setup not yet started)";
+                    return (SessionStatus.AwaitingUser,
+                        $"Device Setup completed; awaiting user / Account Setup phase — agent silent, within {graceHours}h grace{acct}");
+                }
+
+                return (SessionStatus.Incomplete,
+                    $"No completion signal within {graceHours}h grace after Device Setup completed " +
+                    $"(last Account Setup {rollup.AccountSetupSucceededCount}/{rollup.AccountSetupTotal})");
+            }
+
+            // 4. Silent before Device Setup completed, with no explicit failure → unknown, not a failure.
+            return (SessionStatus.Incomplete,
+                "No Device Setup completion or explicit failure signal observed before timeout");
+        }
+
+        private static bool Eq(string a, string b) =>
+            string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Backend/AutopilotMonitor.Functions/Services/EnrollmentTimeoutClassifier.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/EnrollmentTimeoutClassifier.cs
@@ -79,7 +79,8 @@ namespace AutopilotMonitor.Functions.Services
             int AccountSetupTotal,
             bool AccountSetupAllSucceeded,
             bool HasExplicitFailure,
-            bool HasTerminalComplete);
+            bool HasTerminalComplete,
+            bool HasAgentEmergencyBreak);
 
         /// <summary>
         /// Walk a session's events and distill the ESP rollup. Tolerant of missing/empty input
@@ -94,7 +95,7 @@ namespace AutopilotMonitor.Functions.Services
             bool deviceAll = false;
             int acctBestN = 0, acctBestM = 0;
             bool acctFallbackAll = false;
-            bool hasFailure = false, hasComplete = false;
+            bool hasFailure = false, hasComplete = false, hasEmergencyBreak = false;
 
             foreach (var evt in events)
             {
@@ -104,6 +105,8 @@ namespace AutopilotMonitor.Functions.Services
                     hasFailure = true;
                 else if (Eq(type, "enrollment_complete") || Eq(type, "whiteglove_complete"))
                     hasComplete = true;
+                else if (Eq(type, "agent_emergency_break"))
+                    hasEmergencyBreak = true;
 
                 var msg = evt.Message;
                 if (string.IsNullOrEmpty(msg)) continue;
@@ -141,7 +144,8 @@ namespace AutopilotMonitor.Functions.Services
                 AccountSetupTotal: acctBestM,
                 AccountSetupAllSucceeded: acctAll,
                 HasExplicitFailure: hasFailure,
-                HasTerminalComplete: hasComplete);
+                HasTerminalComplete: hasComplete,
+                HasAgentEmergencyBreak: hasEmergencyBreak);
         }
 
         /// <summary>
@@ -166,7 +170,14 @@ namespace AutopilotMonitor.Functions.Services
                 return (SessionStatus.Succeeded,
                     "Reconciled at timeout: Account Setup completed (all subcategories succeeded / enrollment_complete observed)");
 
-            // 3. Device Setup fully provisioned (device is AADJ + MDM-enrolled), user phase pending.
+            // 3. The agent's absolute-age emergency break fired — the agent has cleaned up and exited, so
+            //    nothing more will ever arrive for this session. Terminalize NOW (skip the AwaitingUser grace):
+            //    it did not complete (2) and did not explicitly fail (1), so the honest verdict is Incomplete.
+            if (rollup.HasAgentEmergencyBreak)
+                return (SessionStatus.Incomplete,
+                    "Agent emergency break fired (absolute session-age cap) — agent gone without completion");
+
+            // 4. Device Setup fully provisioned (device is AADJ + MDM-enrolled), user phase pending.
             if (rollup.DeviceSetupAllSucceeded)
             {
                 var elapsedHours = (nowUtc - startedAtUtc).TotalHours;
@@ -184,7 +195,7 @@ namespace AutopilotMonitor.Functions.Services
                     $"(last Account Setup {rollup.AccountSetupSucceededCount}/{rollup.AccountSetupTotal})");
             }
 
-            // 4. Silent before Device Setup completed, with no explicit failure → unknown, not a failure.
+            // 5. Silent before Device Setup completed, with no explicit failure → unknown, not a failure.
             return (SessionStatus.Incomplete,
                 "No Device Setup completion or explicit failure signal observed before timeout");
         }

--- a/src/Backend/AutopilotMonitor.Functions/Services/EnrollmentTimeoutClassifier.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/EnrollmentTimeoutClassifier.cs
@@ -28,8 +28,16 @@ namespace AutopilotMonitor.Functions.Services
 
         /// <summary>Fallback agent absolute session-age cap (AgentConfiguration.AbsoluteMaxSessionHours) when a tenant hasn't overridden it.</summary>
         public const int DefaultAbsoluteMaxSessionHours = 48;
-        /// <summary>Extra hours added on top of the agent's absolute cap before a silent session graduates to Incomplete — covers last-mile spooled telemetry landing after network recovery.</summary>
-        public const int DefaultGraceBufferHours = 12;
+        /// <summary>
+        /// Small margin added on top of the agent's absolute cap before a silent session graduates to
+        /// Incomplete. A completion can only ever arrive ≤ the cap (the agent self-destructs at the cap and
+        /// sends nothing after), so this does NOT need to wait hours for stragglers — it only has to (a) span
+        /// one 2h maintenance-sweep cycle so a boundary session is reliably picked up on the next tick, and
+        /// (b) let a single in-flight event land / absorb minor session.created↔StartedAt clock skew. Kept
+        /// small on purpose: the reconcile path heals any prematurely-set Incomplete back to Succeeded, so a
+        /// tight buffer costs at most a brief flicker, never a wrong terminal state.
+        /// </summary>
+        public const int DefaultGraceBufferHours = 3;
 
         /// <summary>
         /// Resolve the effective backend grace window. The grace MUST never be shorter than the agent's

--- a/src/Backend/AutopilotMonitor.Functions/Services/EnrollmentTimeoutClassifier.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/EnrollmentTimeoutClassifier.cs
@@ -26,6 +26,29 @@ namespace AutopilotMonitor.Functions.Services
         private const string DeviceSetup = "DeviceSetup";
         private const string AccountSetup = "AccountSetup";
 
+        /// <summary>Fallback agent absolute session-age cap (AgentConfiguration.AbsoluteMaxSessionHours) when a tenant hasn't overridden it.</summary>
+        public const int DefaultAbsoluteMaxSessionHours = 48;
+        /// <summary>Extra hours added on top of the agent's absolute cap before a silent session graduates to Incomplete — covers last-mile spooled telemetry landing after network recovery.</summary>
+        public const int DefaultGraceBufferHours = 12;
+
+        /// <summary>
+        /// Resolve the effective backend grace window. The grace MUST never be shorter than the agent's
+        /// absolute session-age cap (<c>AbsoluteMaxSessionHours</c>, default 48h) — until that cap fires the
+        /// agent may legitimately still be enrolling, so terminalizing to Incomplete earlier would race a
+        /// real completion. And because the agent's 48h emergency break is SILENT to the backend (it writes a
+        /// local marker, cleans up and exits without a terminal event), anything still silent past cap+buffer
+        /// is provably dead. So: effective grace = max(agentAbsoluteCap + buffer, tenant override).
+        /// A tenant override of 0/null means "auto-derive".
+        /// </summary>
+        public static int ResolveGraceHours(int? configuredGraceHours, int? absoluteMaxSessionHours, int bufferHours = DefaultGraceBufferHours)
+        {
+            var absMax = absoluteMaxSessionHours.GetValueOrDefault(DefaultAbsoluteMaxSessionHours);
+            if (absMax <= 0) absMax = DefaultAbsoluteMaxSessionHours;
+            var floor = absMax + Math.Max(0, bufferHours);
+            var configured = configuredGraceHours.GetValueOrDefault(0);
+            return Math.Max(floor, configured);
+        }
+
         // "ESP provisioning status: AccountSetup — 5 of 5 subcategories completed"
         private static readonly Regex RollupRegex = new(
             @"ESP provisioning status:\s*(?<cat>DeviceSetup|AccountSetup)\s*[—-]\s*(?<n>\d+)\s+of\s+(?<m>\d+)\s+subcategories completed",

--- a/src/Backend/AutopilotMonitor.Functions/Services/FailureSnapshotBuilder.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/FailureSnapshotBuilder.cs
@@ -24,7 +24,10 @@ namespace AutopilotMonitor.Functions.Services
     /// </summary>
     public static class FailureSnapshotBuilder
     {
-        public const int CurrentSchemaVersion = 1;
+        // v2 (2026-07-08): added the ESP DeviceSetup/AccountSetup subcategory rollup fields
+        // (deviceSetupAllSucceeded / accountSetup*) that the timeout reclassification uses —
+        // see docs/design/enrollment-status-reclassification.md.
+        public const int CurrentSchemaVersion = 2;
 
         // Canonical signals we expect to have seen by the time a healthy session completes.
         // Missing entries are surfaced in the snapshot under "missingSignals". Some entries
@@ -204,6 +207,12 @@ namespace AutopilotMonitor.Functions.Services
                 }
             }
 
+            // ---- ESP subcategory rollup (drives timeout reclassification) --------------
+            // Same extraction the maintenance sweep's classifier uses, embedded here so the
+            // snapshot records the exact evidence behind the AwaitingUser/Incomplete/Succeeded
+            // verdict. categorySucceeded is intentionally ignored (Windows never sets it).
+            var espRollup = EnrollmentTimeoutClassifier.ExtractRollup(ordered);
+
             var snapshot = new
             {
                 schemaVersion = CurrentSchemaVersion,
@@ -223,6 +232,10 @@ namespace AutopilotMonitor.Functions.Services
                 isHybridJoin,
                 enrollmentType,
                 lastNetworkState,
+                deviceSetupAllSucceeded = espRollup.DeviceSetupAllSucceeded,
+                accountSetupSucceededCount = espRollup.AccountSetupSucceededCount,
+                accountSetupTotal = espRollup.AccountSetupTotal,
+                accountSetupAllSucceeded = espRollup.AccountSetupAllSucceeded,
                 missingSignals = missing,
             };
 

--- a/src/Backend/AutopilotMonitor.Functions/Services/MaintenanceService.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/MaintenanceService.cs
@@ -409,6 +409,13 @@ namespace AutopilotMonitor.Functions.Services
                                     var timeoutEvent = BuildSessionTimeoutEvent(session, timeoutHours, sessionEvents, now);
                                     await _sessionRepo.StoreEventsBatchAsync(new List<EnrollmentEvent> { timeoutEvent });
 
+                                    // StoreEventsBatchAsync only bumps the orphan side-index, not the
+                                    // session's EventCount, and the terminal reconcile already ran inside
+                                    // UpdateSessionStatusAsync *before* this synthetic event existed. Recount
+                                    // now so the session_timeout event is reflected in the stored EventCount
+                                    // (authoritative recount from the Events table; idempotent + fail-soft).
+                                    await _sessionRepo.ReconcileSessionCountersAsync(session.TenantId, session.SessionId);
+
                                     await _analyzeProducer.EnqueueAsync(new AnalyzeOnEnrollmentEndEnvelope
                                     {
                                         TenantId = session.TenantId,

--- a/src/Backend/AutopilotMonitor.Functions/Services/MaintenanceService.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/MaintenanceService.cs
@@ -279,7 +279,10 @@ namespace AutopilotMonitor.Functions.Services
                     {
                         var config = await _tenantConfigService.GetConfigurationAsync(tenantId);
                         var timeoutHours = config?.SessionTimeoutHours ?? 5;
-                        var graceHours = config?.SessionGraceHours ?? 72;
+                        // Grace is derived from the agent's absolute session-age cap so it can never be
+                        // shorter than the agent could still legitimately be running (see ResolveGraceHours).
+                        var graceHours = EnrollmentTimeoutClassifier.ResolveGraceHours(
+                            config?.SessionGraceHours, config?.AbsoluteMaxSessionHours);
                         const int agentSilenceHours = 2; // fixed policy: 2h silence → Stalled intermediate
                         var now = DateTime.UtcNow;
                         var cutoffTime = now.AddHours(-timeoutHours);

--- a/src/Backend/AutopilotMonitor.Functions/Services/MaintenanceService.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/MaintenanceService.cs
@@ -279,6 +279,7 @@ namespace AutopilotMonitor.Functions.Services
                     {
                         var config = await _tenantConfigService.GetConfigurationAsync(tenantId);
                         var timeoutHours = config?.SessionTimeoutHours ?? 5;
+                        var graceHours = config?.SessionGraceHours ?? 72;
                         const int agentSilenceHours = 2; // fixed policy: 2h silence → Stalled intermediate
                         var now = DateTime.UtcNow;
                         var cutoffTime = now.AddHours(-timeoutHours);
@@ -331,19 +332,23 @@ namespace AutopilotMonitor.Functions.Services
                             continue;
                         }
 
-                        int sessionCount = 0;
+                        int terminalizedCount = 0;   // Failed + Incomplete — the real "timed out" outcomes
+                        int awaitingCount = 0;       // reached timeout but Device Setup done → AwaitingUser (non-terminal)
+                        int reconciledCount = 0;     // late completion detected at the sweep → Succeeded
 
                         foreach (var session in stalledSessions)
                         {
-                            // Hybrid User-Driven completion-gap fix (2026-05-01): before
-                            // graduating the session to terminal Failed, build a compact
-                            // snapshot of "what we last knew" so operators don't have to
-                            // scroll through hundreds of events to reconstruct where the
-                            // session was stuck. Best-effort — a snapshot read failure
-                            // must never block the timeout transition itself.
+                            // Fast path: an AwaitingUser session still inside the grace window needs no
+                            // work and — crucially — no event read (grace is purely time-based). A late
+                            // completion is picked up by the ingest path, so we don't re-scan every pass.
+                            var elapsedHours = (now - session.StartedAt).TotalHours;
+                            if (session.Status == SessionStatus.AwaitingUser && elapsedHours < graceHours)
+                                continue;
+
+                            // Build a compact snapshot of "what we last knew" (Hybrid User-Driven
+                            // completion-gap fix, 2026-05-01) plus the ESP rollup that drives the
+                            // reclassification. Best-effort — a read failure must never block the sweep.
                             string? snapshotJson = null;
-                            // Reused below to assign the synthetic session_timeout a Sequence after the
-                            // session's last event so it sorts last in the canonical Sequence order.
                             List<EnrollmentEvent> sessionEvents = new();
                             try
                             {
@@ -354,26 +359,47 @@ namespace AutopilotMonitor.Functions.Services
                             catch (Exception snapEx)
                             {
                                 _logger.LogWarning(snapEx,
-                                    $"Failed to build failure snapshot for session {session.SessionId}; proceeding with timeout transition without snapshot");
+                                    $"Failed to read events for session {session.SessionId}; proceeding with timeout classification without snapshot");
                             }
+
+                            // Timeout ≠ failure. Classify from the ESP subcategory rollup the agent already
+                            // emits instead of blindly failing every silent session
+                            // (docs/design/enrollment-status-reclassification.md): explicit failure → Failed;
+                            // Account Setup all-succeeded / enrollment_complete → Succeeded (reconcile);
+                            // Device Setup done + within grace → AwaitingUser, else Incomplete; silent before
+                            // Device Setup → Incomplete. Never Failed without an explicit failure signal.
+                            var rollup = EnrollmentTimeoutClassifier.ExtractRollup(sessionEvents);
+                            var (targetStatus, reason) = EnrollmentTimeoutClassifier.ClassifyTimedOutSession(
+                                rollup, session.StartedAt, now, graceHours);
+
+                            // No-op if the verdict equals the current (non-terminal) state.
+                            if (targetStatus == session.Status)
+                                continue;
 
                             var transitioned = await _sessionRepo.UpdateSessionStatusAsync(
                                 session.TenantId,
                                 session.SessionId,
-                                SessionStatus.Failed,
-                                failureReason: $"Session timed out after {timeoutHours} hours (started at {session.StartedAt:yyyy-MM-dd HH:mm:ss} UTC)",
+                                targetStatus,
+                                failureReason: reason,
                                 failureSnapshotJson: snapshotJson
                             );
-                            sessionCount++;
 
-                            // Parity with the agent max-lifetime path: the status flip alone is invisible to the
-                            // analyze pipeline (it fires on stream events, not on a repo status change), so a
-                            // server-timed-out session would otherwise analyze to totalIssues:0. Emit a terminal
-                            // session_timeout event into the stream and enqueue auto-analyze so ANALYZE-ENRL-002
-                            // fires. Gated on the real first transition (transitioned==true) so a re-run or an
-                            // already-terminal session can never produce a duplicate event. Best-effort — a
-                            // failure here must never break the maintenance sweep.
-                            if (transitioned)
+                            if (!transitioned)
+                                continue;
+
+                            switch (targetStatus)
+                            {
+                                case SessionStatus.AwaitingUser: awaitingCount++; break;
+                                case SessionStatus.Succeeded: reconciledCount++; break;
+                                default: terminalizedCount++; break; // Failed / Incomplete
+                            }
+
+                            // Only the terminal "sweep-terminalized" outcomes (Failed / Incomplete) get the
+                            // synthetic session_timeout event + auto-analyze, so the analyze pipeline
+                            // (ANALYZE-ENRL-002) still has a terminal event to fire on — parity with the agent
+                            // max-lifetime path. AwaitingUser is non-terminal and Succeeded is a reconcile, so
+                            // neither emits a timeout artifact. Best-effort — a failure here must not break the sweep.
+                            if (targetStatus == SessionStatus.Failed || targetStatus == SessionStatus.Incomplete)
                             {
                                 try
                                 {
@@ -391,28 +417,42 @@ namespace AutopilotMonitor.Functions.Services
                                 catch (Exception emitEx)
                                 {
                                     _logger.LogWarning(emitEx,
-                                        $"Failed to emit session_timeout event / enqueue analyze for session {session.SessionId}; timeout transition stands");
+                                        $"Failed to emit session_timeout event / enqueue analyze for session {session.SessionId}; transition stands");
                                 }
                             }
                         }
 
-                        totalSessionsTimedOut += sessionCount;
+                        totalSessionsTimedOut += terminalizedCount;
 
-                        await _maintenanceRepo.LogAuditEntryAsync(
-                            tenantId,
-                            "SessionTimeout",
-                            "Session",
-                            $"{sessionCount} sessions",
-                            "System.Maintenance",
-                            new Dictionary<string, string>
-                            {
-                                { "SessionsTimedOut", sessionCount.ToString() },
-                                { "TimeoutHours", timeoutHours.ToString() },
-                                { "CutoffTime", cutoffTime.ToString("yyyy-MM-dd HH:mm:ss") }
-                            });
+                        // Only record when the sweep actually did something this pass — otherwise every
+                        // 2h tick over a backlog of within-grace AwaitingUser sessions would spam a 0-count
+                        // audit entry + ops event.
+                        if (terminalizedCount + awaitingCount + reconciledCount > 0)
+                        {
+                            await _maintenanceRepo.LogAuditEntryAsync(
+                                tenantId,
+                                "SessionTimeout",
+                                "Session",
+                                $"{terminalizedCount} sessions",
+                                "System.Maintenance",
+                                new Dictionary<string, string>
+                                {
+                                    { "SessionsTimedOut", terminalizedCount.ToString() },
+                                    { "SessionsAwaitingUser", awaitingCount.ToString() },
+                                    { "SessionsReconciled", reconciledCount.ToString() },
+                                    { "TimeoutHours", timeoutHours.ToString() },
+                                    { "GraceHours", graceHours.ToString() },
+                                    { "CutoffTime", cutoffTime.ToString("yyyy-MM-dd HH:mm:ss") }
+                                });
 
-                        _logger.LogInformation($"Tenant {tenantId}: Marked {sessionCount} stalled sessions as timed out (timeout: {timeoutHours}h)");
-                        await _opsEventService.RecordSessionTimeoutsAsync(tenantId, sessionCount, timeoutHours);
+                            _logger.LogInformation(
+                                $"Tenant {tenantId}: timeout sweep — {terminalizedCount} terminalized (Failed/Incomplete), " +
+                                $"{awaitingCount} held AwaitingUser, {reconciledCount} reconciled to Succeeded " +
+                                $"(timeout: {timeoutHours}h, grace: {graceHours}h)");
+
+                            if (terminalizedCount > 0)
+                                await _opsEventService.RecordSessionTimeoutsAsync(tenantId, terminalizedCount, timeoutHours);
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/src/Backend/AutopilotMonitor.Functions/Services/TableStorageService.AgentApi.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/TableStorageService.AgentApi.cs
@@ -1315,20 +1315,30 @@ namespace AutopilotMonitor.Functions.Services
                 TallyMetricsSummaryRow(groups, entity);
             }
 
-            return groups.Select(kvp => (object)new
+            return groups.Select(kvp =>
             {
-                tenantId = kvp.Key,
-                totalSessions = kvp.Value.Total,
-                succeeded = kvp.Value.Succeeded,
-                failed = kvp.Value.Failed,
-                inProgress = kvp.Value.InProgress,
-                pending = kvp.Value.Pending,
-                stalled = kvp.Value.Stalled,
-                other = kvp.Value.Other,
-                failureRate = kvp.Value.Total > 0
-                    ? Math.Round((double)kvp.Value.Failed / kvp.Value.Total * 100, 1)
-                    : 0.0,
-                windowDays = days
+                var b = kvp.Value;
+                // Honest failure rate: failed over the TERMINAL outcomes only (Succeeded + Failed).
+                // Incomplete (unknown, non-failure) is deliberately excluded from the denominator, and
+                // non-terminal states (InProgress/AwaitingUser/Pending/Stalled) never belonged in it.
+                var terminal = b.Succeeded + b.Failed;
+                return (object)new
+                {
+                    tenantId = kvp.Key,
+                    totalSessions = b.Total,
+                    succeeded = b.Succeeded,
+                    failed = b.Failed,
+                    inProgress = b.InProgress,
+                    pending = b.Pending,
+                    stalled = b.Stalled,
+                    awaitingUser = b.AwaitingUser,
+                    incomplete = b.Incomplete,
+                    other = b.Other,
+                    failureRate = terminal > 0
+                        ? Math.Round((double)b.Failed / terminal * 100, 1)
+                        : 0.0,
+                    windowDays = days
+                };
             }).ToList();
         }
     }

--- a/src/Backend/AutopilotMonitor.Functions/Services/TableStorageService.Maintenance.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/TableStorageService.Maintenance.cs
@@ -560,12 +560,15 @@ namespace AutopilotMonitor.Functions.Services
                 var tableClient = _tableServiceClient.GetTableClient(Constants.TableNames.Sessions);
 
                 // Eligible for the 5h-timeout sweep: InProgress or Stalled sessions (Stalled is a
-                // non-terminal intermediate state set earlier by either the agent or the 2h sweep;
-                // when the 5h mark is reached without healing, the session graduates to Failed).
+                // non-terminal intermediate state set earlier by either the agent or the 2h sweep).
+                // At the 5h mark the session is reclassified rather than blindly failed — see
+                // EnrollmentTimeoutClassifier. AwaitingUser is included too so it keeps being
+                // re-evaluated each pass and graduates to Incomplete once SessionGraceHours elapses
+                // (docs/design/enrollment-status-reclassification.md).
                 // IsPreProvisioned ne true → WhiteGlove sessions are intentionally long-lived and
                 // must never be timed out, even after months in storage.
                 var filter = $"PartitionKey eq '{tenantId}' " +
-                             $"and (Status eq 'InProgress' or Status eq 'Stalled') " +
+                             $"and (Status eq 'InProgress' or Status eq 'Stalled' or Status eq 'AwaitingUser') " +
                              $"and StartedAt lt datetime'{cutoffTime:yyyy-MM-ddTHH:mm:ss}Z' " +
                              $"and IsPreProvisioned ne true";
                 var query = tableClient.QueryAsync<TableEntity>(filter: filter);

--- a/src/Backend/AutopilotMonitor.Functions/Services/TableStorageService.Sessions.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/TableStorageService.Sessions.cs
@@ -1363,16 +1363,27 @@ namespace AutopilotMonitor.Functions.Services
                     var entity = await tableClient.GetEntityAsync<TableEntity>(tenantId, sessionId);
                     var session = entity.Value;
 
-                    // Idempotency: if the session is already in a terminal state (Succeeded/Failed),
-                    // do not overwrite it with another terminal state to prevent duplicate notifications.
+                    // Idempotency: never overwrite one terminal state with another. Terminal states
+                    // are Succeeded, Failed and Incomplete (docs/design/enrollment-status-reclassification.md).
+                    // Reconciling a Failed/Incomplete session UP to Succeeded on a late completion is
+                    // done on the dedicated reconcile path, not here.
                     var existingStatusStr = session.GetString("Status");
-                    if (status == SessionStatus.Succeeded || status == SessionStatus.Failed)
+                    bool incomingTerminal = status == SessionStatus.Succeeded
+                        || status == SessionStatus.Failed
+                        || status == SessionStatus.Incomplete;
+                    bool existingTerminal = existingStatusStr == SessionStatus.Succeeded.ToString()
+                        || existingStatusStr == SessionStatus.Failed.ToString()
+                        || existingStatusStr == SessionStatus.Incomplete.ToString();
+                    if (incomingTerminal && existingTerminal)
                     {
-                        if (existingStatusStr == SessionStatus.Succeeded.ToString() || existingStatusStr == SessionStatus.Failed.ToString())
-                        {
-                            _logger.LogInformation($"Session {sessionId} already in terminal state '{existingStatusStr}', skipping status update to '{status}'");
-                            return false;
-                        }
+                        _logger.LogInformation($"Session {sessionId} already in terminal state '{existingStatusStr}', skipping status update to '{status}'");
+                        return false;
+                    }
+                    // AwaitingUser is non-terminal but must never regress a terminal session.
+                    if (status == SessionStatus.AwaitingUser && existingTerminal)
+                    {
+                        _logger.LogInformation($"Session {sessionId} already terminal '{existingStatusStr}', skipping AwaitingUser update");
+                        return false;
                     }
 
                     // Build a Merge update with only the fields that actually change
@@ -1487,6 +1498,16 @@ namespace AutopilotMonitor.Functions.Services
                                 update["DurationSeconds"] = (int)(latestEventTimestamp.Value - durationStart).TotalSeconds;
                         }
                     }
+                    // Incomplete is terminal but not a completion — stamp a terminal timestamp so the
+                    // session reads as closed, but do NOT compute DurationSeconds (a ~grace-length span
+                    // would skew duration stats, and Incomplete is excluded from those anyway).
+                    else if (status == SessionStatus.Incomplete)
+                    {
+                        update["CompletedAt"] = EnsureUtc(ResolveCompletionTimestamp(
+                            completedAt,
+                            session.GetDateTimeOffset("LastEventAt")?.UtcDateTime,
+                            DateTime.UtcNow));
+                    }
 
                     // Track the most recent event timestamp for excessive data sender detection
                     if (latestEventTimestamp.HasValue)
@@ -1496,8 +1517,11 @@ namespace AutopilotMonitor.Functions.Services
                             update["LastEventAt"] = EnsureUtc(latestEventTimestamp.Value);
                     }
 
-                    // Set failure reason if failed
-                    if (status == SessionStatus.Failed && !string.IsNullOrEmpty(failureReason))
+                    // Set the reason string for the sweep-authored states. Failed keeps its failure
+                    // reason; Incomplete and AwaitingUser carry the informational classification reason
+                    // (same field reuse as the Stalled path below), so the UI can explain the state.
+                    if ((status == SessionStatus.Failed || status == SessionStatus.Incomplete || status == SessionStatus.AwaitingUser)
+                        && !string.IsNullOrEmpty(failureReason))
                     {
                         update["FailureReason"] = failureReason;
                     }
@@ -1507,7 +1531,8 @@ namespace AutopilotMonitor.Functions.Services
                     // fix, 2026-05-01); other terminal paths leave the field untouched, which
                     // is fine — null/empty means "no snapshot available" and the UI falls back
                     // to the existing FailureReason rendering.
-                    if (status == SessionStatus.Failed && !string.IsNullOrEmpty(failureSnapshotJson))
+                    if ((status == SessionStatus.Failed || status == SessionStatus.Incomplete || status == SessionStatus.AwaitingUser)
+                        && !string.IsNullOrEmpty(failureSnapshotJson))
                     {
                         update["FailureSnapshotJson"] = failureSnapshotJson;
                     }

--- a/src/Backend/AutopilotMonitor.Functions/Services/TableStorageService.Sessions.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/TableStorageService.Sessions.cs
@@ -1033,6 +1033,7 @@ namespace AutopilotMonitor.Functions.Services
             int active = 0;
             int succeeded = 0;
             int failed = 0;
+            int incomplete = 0;
             long succeededDurationSeconds = 0;
             int succeededWithDurationCount = 0;
             int totalToday = 0;
@@ -1061,6 +1062,10 @@ namespace AutopilotMonitor.Functions.Services
                     case SessionStatus.Failed:
                         failed++;
                         break;
+                    case SessionStatus.Incomplete:
+                        // Terminal, non-failure. Reported separately, kept out of the failure rate.
+                        incomplete++;
+                        break;
                 }
 
                 if (s.StartedAt >= utcMidnight)
@@ -1085,6 +1090,7 @@ namespace AutopilotMonitor.Functions.Services
                 TotalLastNDays = sessions.Count,
                 SucceededLastNDays = succeeded,
                 FailedLastNDays = failed,
+                IncompleteLastNDays = incomplete,
                 SuccessRatePct = successRatePct,
                 AvgDurationMinutes = avgDurationMinutes,
                 TotalToday = totalToday,

--- a/src/Backend/AutopilotMonitor.Functions/Services/TableStorageService.Sessions.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/TableStorageService.Sessions.cs
@@ -534,16 +534,21 @@ namespace AutopilotMonitor.Functions.Services
                 for (var casAttempt = 0; ; casAttempt++)
                 {
                     Azure.ETag? freshEtag = null;
-                    string? freshDeletionState = null;
-                    string? freshPendingDeletionManifestId = null;
+                    TableEntity? freshEntity = null;
                     try
                     {
                         var freshResponse = await tableClient.GetEntityAsync<TableEntity>(
                             registration.TenantId, registration.SessionId,
-                            select: new[] { "DeletionState", "PendingDeletionManifestId" });
+                            select: new[]
+                            {
+                                "DeletionState", "PendingDeletionManifestId",
+                                // Terminal tuple — re-read so a terminal verdict that landed in the
+                                // fresh-read window isn't reverted by the Replace below (see guard).
+                                "Status", "CurrentPhase", "CompletedAt", "FailureReason",
+                                "FailureSnapshotJson", "FailureSource", "AdminMarkedAction", "DurationSeconds",
+                            });
                         freshEtag = freshResponse.Value.ETag;
-                        freshDeletionState = freshResponse.Value.GetString("DeletionState");
-                        freshPendingDeletionManifestId = freshResponse.Value.GetString("PendingDeletionManifestId");
+                        freshEntity = freshResponse.Value;
                     }
                     catch (RequestFailedException ex) when (ex.Status == 404)
                     {
@@ -555,6 +560,8 @@ namespace AutopilotMonitor.Functions.Services
                     // Stamp cascade-lock columns from the FRESH read so the Replace below
                     // doesn't silently clear them. This kicks in even when the initial read
                     // saw None and the producer transitioned to Preparing in between.
+                    var freshDeletionState = freshEntity?.GetString("DeletionState");
+                    var freshPendingDeletionManifestId = freshEntity?.GetString("PendingDeletionManifestId");
                     if (!string.IsNullOrEmpty(freshDeletionState))
                         entity["DeletionState"] = freshDeletionState;
                     else if (!string.IsNullOrEmpty(existingDeletionState))
@@ -563,6 +570,30 @@ namespace AutopilotMonitor.Functions.Services
                         entity["PendingDeletionManifestId"] = freshPendingDeletionManifestId;
                     else if (!string.IsNullOrEmpty(existingPendingDeletionManifestId))
                         entity["PendingDeletionManifestId"] = existingPendingDeletionManifestId;
+
+                    // Guard the fresh-read window against a just-landed terminal. The initial-read
+                    // guard at the top only sees the status as of the FIRST read; a terminal verdict
+                    // (Succeeded/Failed/Incomplete — e.g. maintenance setting Incomplete, or a late
+                    // completion setting Succeeded) can land between that read and this ETag-bound
+                    // Replace. Without this the Replace would silently regress the terminal back to the
+                    // stale registration status (and lose its completion/failure tuple). Terminal states
+                    // are authoritative and irreversible — re-stamp the fresh terminal tuple verbatim so
+                    // re-registration can never revert them (parity with IsTerminalTransitionAllowed).
+                    var freshStatus = freshEntity?.GetString("Status");
+                    if (freshStatus == SessionStatus.Succeeded.ToString()
+                        || freshStatus == SessionStatus.Failed.ToString()
+                        || freshStatus == SessionStatus.Incomplete.ToString())
+                    {
+                        entity["Status"] = freshStatus;
+                        foreach (var col in new[] { "CurrentPhase", "CompletedAt", "FailureReason", "FailureSnapshotJson", "FailureSource", "AdminMarkedAction", "DurationSeconds" })
+                        {
+                            if (freshEntity!.TryGetValue(col, out var val) && val is not null)
+                                entity[col] = val;
+                            else
+                                entity.Remove(col); // absent on the fresh terminal row → don't carry a stale value through the Replace
+                        }
+                        _logger.LogInformation($"Session {registration.SessionId}: terminal '{freshStatus}' landed during re-registration, preserving it over the Replace");
+                    }
 
                     try
                     {
@@ -1666,12 +1697,28 @@ namespace AutopilotMonitor.Functions.Services
                             var freshEntity = await forceTableClient.GetEntityAsync<TableEntity>(tenantId, sessionId);
                             var freshSession = freshEntity.Value;
 
-                            // Re-check idempotency: do not overwrite a terminal state
+                            // Re-check the transition guard against the freshly-read status using the
+                            // SAME pure predicate as the normal path (IsTerminalTransitionAllowed) — the
+                            // old hard-coded Succeeded/Failed check predated Incomplete/AwaitingUser and
+                            // would let an unconditional force-write regress a terminal that landed during
+                            // our retries (e.g. an Incomplete verdict stomping a concurrently-written
+                            // Succeeded/Failed, or a second Incomplete overwriting the first).
                             var freshStatusStr = freshSession.GetString("Status");
-                            if ((status == SessionStatus.Succeeded || status == SessionStatus.Failed) &&
-                                (freshStatusStr == SessionStatus.Succeeded.ToString() || freshStatusStr == SessionStatus.Failed.ToString()))
+                            if (!IsTerminalTransitionAllowed(freshStatusStr, status))
                             {
-                                _logger.LogInformation($"Session {sessionId} reached terminal state '{freshStatusStr}' during retries, skipping force write");
+                                _logger.LogInformation($"Session {sessionId}: transition '{freshStatusStr}' → '{status}' not allowed (terminal/reconcile guard), skipping force write");
+                                return false;
+                            }
+
+                            // Preserve an administrator's explicit terminal decision — mirror the normal
+                            // path: a late-completion reconcile (Succeeded upgrading Failed/Incomplete) must
+                            // never silently override a session an admin marked terminal by hand.
+                            if (status == SessionStatus.Succeeded
+                                && !string.IsNullOrEmpty(freshSession.GetString("AdminMarkedAction"))
+                                && (freshStatusStr == SessionStatus.Failed.ToString()
+                                    || freshStatusStr == SessionStatus.Incomplete.ToString()))
+                            {
+                                _logger.LogInformation($"Session {sessionId}: admin-marked terminal '{freshStatusStr}', not auto-reconciling to Succeeded (force path)");
                                 return false;
                             }
 
@@ -1692,6 +1739,11 @@ namespace AutopilotMonitor.Functions.Services
                             if (status == SessionStatus.Succeeded)
                             {
                                 forceUpdate["CurrentPhase"] = (int)EnrollmentPhase.Complete;
+                                // Mirror the normal path: a (re)Succeeded session carries no failure
+                                // reason/snapshot — clear anything left from a prior Failed/Incomplete/
+                                // AwaitingUser verdict so a late-completed device shows no stale reason.
+                                forceUpdate["FailureReason"] = string.Empty;
+                                forceUpdate["FailureSnapshotJson"] = string.Empty;
                             }
                             else if (status == SessionStatus.Failed)
                             {
@@ -1745,6 +1797,17 @@ namespace AutopilotMonitor.Functions.Services
                                         forceUpdate["DurationSeconds"] = (int)(latestEventTimestamp.Value - durationStart).TotalSeconds;
                                 }
                             }
+                            // Mirror the normal path: Incomplete is terminal but not a completion — stamp a
+                            // terminal timestamp so the session reads as closed, but do NOT compute
+                            // DurationSeconds (a ~grace-length span would skew stats, and Incomplete is
+                            // excluded from those anyway). AwaitingUser is non-terminal → no CompletedAt.
+                            else if (status == SessionStatus.Incomplete)
+                            {
+                                forceUpdate["CompletedAt"] = EnsureUtc(ResolveCompletionTimestamp(
+                                    completedAt,
+                                    freshSession.GetDateTimeOffset("LastEventAt")?.UtcDateTime,
+                                    DateTime.UtcNow));
+                            }
 
                             if (latestEventTimestamp.HasValue)
                             {
@@ -1753,12 +1816,19 @@ namespace AutopilotMonitor.Functions.Services
                                     forceUpdate["LastEventAt"] = EnsureUtc(latestEventTimestamp.Value);
                             }
 
-                            if (status == SessionStatus.Failed && !string.IsNullOrEmpty(failureReason))
+                            // Mirror the normal path: Incomplete/AwaitingUser carry the classification
+                            // reason too (same field reuse as Failed), not just Failed — otherwise the
+                            // force-merge fallback persists a reason-less Incomplete/AwaitingUser under
+                            // ETag contention and the UI can't explain the state.
+                            if ((status == SessionStatus.Failed || status == SessionStatus.Incomplete || status == SessionStatus.AwaitingUser)
+                                && !string.IsNullOrEmpty(failureReason))
                                 forceUpdate["FailureReason"] = failureReason;
 
-                            // Mirror the FailureSnapshotJson from the regular path so the
-                            // force-merge fallback never silently drops the snapshot.
-                            if (status == SessionStatus.Failed && !string.IsNullOrEmpty(failureSnapshotJson))
+                            // Mirror the FailureSnapshotJson from the regular path so the force-merge
+                            // fallback never silently drops the snapshot — the maintenance timeout path
+                            // supplies it for Incomplete/AwaitingUser as well, not only Failed.
+                            if ((status == SessionStatus.Failed || status == SessionStatus.Incomplete || status == SessionStatus.AwaitingUser)
+                                && !string.IsNullOrEmpty(failureSnapshotJson))
                                 forceUpdate["FailureSnapshotJson"] = failureSnapshotJson;
 
                             // Mirror FailureSource (failure attribution: agent / rule:<id> / manual)

--- a/src/Backend/AutopilotMonitor.Functions/Services/TableStorageService.Sessions.cs
+++ b/src/Backend/AutopilotMonitor.Functions/Services/TableStorageService.Sessions.cs
@@ -1345,6 +1345,33 @@ namespace AutopilotMonitor.Functions.Services
         /// back to the session's LastEventAt and only to UtcNow as a last resort, so DurationSeconds
         /// reflects when the session went silent rather than when the operator clicked the button.
         /// </param>
+        /// <summary>
+        /// Pure gate for the terminal/reconcile status rules (docs/design/enrollment-status-reclassification.md).
+        /// Returns whether a write to <paramref name="incoming"/> may proceed given the persisted
+        /// <paramref name="existingStatus"/> string:
+        /// <list type="bullet">
+        /// <item>Succeeded may UPGRADE any non-Succeeded state (late completion reconcile); idempotent no-op if already Succeeded.</item>
+        /// <item>Failed / Incomplete (silent-terminal verdicts) never overwrite an existing terminal (Succeeded/Failed/Incomplete).</item>
+        /// <item>AwaitingUser never regresses an existing terminal.</item>
+        /// <item>Non-terminal incoming statuses (InProgress/Stalled/Pending) are allowed here and governed by their own downstream guards.</item>
+        /// </list>
+        /// Static + pure so the reconcile matrix is unit-testable without Table Storage.
+        /// </summary>
+        internal static bool IsTerminalTransitionAllowed(string? existingStatus, SessionStatus incoming)
+        {
+            bool existingTerminal = existingStatus == SessionStatus.Succeeded.ToString()
+                || existingStatus == SessionStatus.Failed.ToString()
+                || existingStatus == SessionStatus.Incomplete.ToString();
+
+            return incoming switch
+            {
+                SessionStatus.Succeeded => existingStatus != SessionStatus.Succeeded.ToString(),
+                SessionStatus.Failed or SessionStatus.Incomplete => !existingTerminal,
+                SessionStatus.AwaitingUser => !existingTerminal,
+                _ => true,
+            };
+        }
+
         public async Task<bool> UpdateSessionStatusAsync(string tenantId, string sessionId, SessionStatus status, EnrollmentPhase? currentPhase = null, string? failureReason = null, DateTime? completedAt = null, DateTime? earliestEventTimestamp = null, DateTime? latestEventTimestamp = null, bool? isPreProvisioned = null, bool? isUserDriven = null, DateTime? resumedAt = null, DateTime? stalledAt = null, bool clearStalledAt = false, bool clearFailureReason = false, string? failureSource = null, string? adminMarkedAction = null, string? failureSnapshotJson = null)
         {
             SecurityValidator.EnsureValidGuid(tenantId, nameof(tenantId));
@@ -1363,26 +1390,28 @@ namespace AutopilotMonitor.Functions.Services
                     var entity = await tableClient.GetEntityAsync<TableEntity>(tenantId, sessionId);
                     var session = entity.Value;
 
-                    // Idempotency: never overwrite one terminal state with another. Terminal states
-                    // are Succeeded, Failed and Incomplete (docs/design/enrollment-status-reclassification.md).
-                    // Reconciling a Failed/Incomplete session UP to Succeeded on a late completion is
-                    // done on the dedicated reconcile path, not here.
+                    // Terminal / reconcile transition gate (docs/design/enrollment-status-reclassification.md):
+                    // a genuine completion (Succeeded) may UPGRADE a prior Failed/Incomplete/AwaitingUser
+                    // verdict — a device that reached the desktop is enrolled regardless of an earlier timeout
+                    // guess — but the silent-terminal verdicts (Failed/Incomplete) and AwaitingUser never
+                    // overwrite an existing terminal. Non-terminal incoming statuses fall through to their
+                    // own guards below.
                     var existingStatusStr = session.GetString("Status");
-                    bool incomingTerminal = status == SessionStatus.Succeeded
-                        || status == SessionStatus.Failed
-                        || status == SessionStatus.Incomplete;
-                    bool existingTerminal = existingStatusStr == SessionStatus.Succeeded.ToString()
-                        || existingStatusStr == SessionStatus.Failed.ToString()
-                        || existingStatusStr == SessionStatus.Incomplete.ToString();
-                    if (incomingTerminal && existingTerminal)
+                    if (!IsTerminalTransitionAllowed(existingStatusStr, status))
                     {
-                        _logger.LogInformation($"Session {sessionId} already in terminal state '{existingStatusStr}', skipping status update to '{status}'");
+                        _logger.LogInformation($"Session {sessionId}: transition '{existingStatusStr}' → '{status}' not allowed (terminal/reconcile guard), skipping");
                         return false;
                     }
-                    // AwaitingUser is non-terminal but must never regress a terminal session.
-                    if (status == SessionStatus.AwaitingUser && existingTerminal)
+
+                    // Preserve an administrator's explicit terminal decision: the late-completion reconcile
+                    // (Succeeded upgrading a Failed/Incomplete row) must never silently override a session an
+                    // admin marked terminal by hand (AdminMarkedAction is set only by the Mark*Session functions).
+                    if (status == SessionStatus.Succeeded
+                        && !string.IsNullOrEmpty(session.GetString("AdminMarkedAction"))
+                        && (existingStatusStr == SessionStatus.Failed.ToString()
+                            || existingStatusStr == SessionStatus.Incomplete.ToString()))
                     {
-                        _logger.LogInformation($"Session {sessionId} already terminal '{existingStatusStr}', skipping AwaitingUser update");
+                        _logger.LogInformation($"Session {sessionId}: admin-marked terminal '{existingStatusStr}', not auto-reconciling to Succeeded");
                         return false;
                     }
 
@@ -1425,6 +1454,11 @@ namespace AutopilotMonitor.Functions.Services
                     if (status == SessionStatus.Succeeded)
                     {
                         update["CurrentPhase"] = (int)EnrollmentPhase.Complete;
+                        // Reconcile hygiene: a session that (re)reaches Succeeded carries no failure reason or
+                        // snapshot — clear anything left from a prior Failed/Incomplete/AwaitingUser verdict so
+                        // a late-completed device doesn't keep showing a stale "timed out" reason.
+                        update["FailureReason"] = string.Empty;
+                        update["FailureSnapshotJson"] = string.Empty;
                     }
                     else if (status == SessionStatus.Failed)
                     {

--- a/src/Shared/AutopilotMonitor.Shared/Constants.cs
+++ b/src/Shared/AutopilotMonitor.Shared/Constants.cs
@@ -305,6 +305,12 @@ namespace AutopilotMonitor.Shared
             public const string AgentVersionCheck         = "agent_version_check";
             public const string AgentStarted              = "agent_started";        // Lifecycle anchor — fired Seq=1 at agent boot. PR1: replaces hardcoded string-literals at emit sites.
             public const string AgentShuttingDown         = "agent_shutting_down";  // V2 single-rail plan §6.2 — terminate-hygiene acknowledgement emitted before CleanupService tears down
+            // Backend-materialized from the agent's best-effort SessionAgeEmergencyBreak error report
+            // (docs/design/enrollment-status-reclassification.md). The agent's 48h absolute session-age
+            // break (Program.Guards.CheckSessionAgeEmergencyBreak) is otherwise silent to the backend; this
+            // event closes that blind spot in the timeline AND tells the timeout classifier the agent is
+            // definitively gone, so the session is terminalized now (by ESP rollup) instead of waiting out grace.
+            public const string AgentEmergencyBreak       = "agent_emergency_break";
             // Low observation coverage: the agent started long after device boot AND lived only
             // briefly before a terminal outcome — i.e. it arrived after the enrollment had already
             // decided, so its diagnosis is a post-mortem of the registry/log end-state, not a live

--- a/src/Shared/AutopilotMonitor.Shared/Models/Config/TenantConfiguration.cs
+++ b/src/Shared/AutopilotMonitor.Shared/Models/Config/TenantConfiguration.cs
@@ -184,6 +184,17 @@ namespace AutopilotMonitor.Shared.Models
         /// </summary>
         public int SessionTimeoutHours { get; set; } = 5;
 
+        /// <summary>
+        /// Grace window in hours for a session that reached the inactivity timeout with Device Setup
+        /// already provisioned but no completion signal yet (docs/design/enrollment-status-reclassification.md).
+        /// At <see cref="SessionTimeoutHours"/> such a session becomes AwaitingUser (non-terminal) instead
+        /// of Failed; only after this longer window elapses without a completion does it graduate to the
+        /// terminal, non-failure Incomplete state. The user/Account-Setup phase legitimately spans hours or
+        /// overnight, so this must be comfortably larger than SessionTimeoutHours.
+        /// Default: 72 hours.
+        /// </summary>
+        public int SessionGraceHours { get; set; } = 72;
+
         // ===== PAYLOAD SETTINGS =====
 
         /// <summary>
@@ -832,6 +843,7 @@ namespace AutopilotMonitor.Shared.Models
                 AllowInsecureAgentRequests = false,
                 DataRetentionDays = 90,
                 SessionTimeoutHours = 5,
+                SessionGraceHours = 72,
                 MaxNdjsonPayloadSizeMB = 5,
                 EnablePerformanceCollector = true,
                 PerformanceCollectorIntervalSeconds = 30,

--- a/src/Shared/AutopilotMonitor.Shared/Models/Config/TenantConfiguration.cs
+++ b/src/Shared/AutopilotMonitor.Shared/Models/Config/TenantConfiguration.cs
@@ -188,12 +188,17 @@ namespace AutopilotMonitor.Shared.Models
         /// Grace window in hours for a session that reached the inactivity timeout with Device Setup
         /// already provisioned but no completion signal yet (docs/design/enrollment-status-reclassification.md).
         /// At <see cref="SessionTimeoutHours"/> such a session becomes AwaitingUser (non-terminal) instead
-        /// of Failed; only after this longer window elapses without a completion does it graduate to the
-        /// terminal, non-failure Incomplete state. The user/Account-Setup phase legitimately spans hours or
-        /// overnight, so this must be comfortably larger than SessionTimeoutHours.
-        /// Default: 72 hours.
+        /// of Failed; only after this window elapses without a completion does it graduate to the terminal,
+        /// non-failure Incomplete state.
+        /// <para>
+        /// 0 (default) = auto-derive: <c>AbsoluteMaxSessionHours + 12h buffer</c> (= 60h with defaults). The
+        /// grace is always floored at the agent's absolute session-age cap plus buffer — until that cap fires
+        /// the agent may still be legitimately enrolling, and because the cap is silent to the backend anything
+        /// still quiet past cap+buffer is provably dead. A non-zero value acts as an override but can only
+        /// raise the effective grace above that floor, never below it (see EnrollmentTimeoutClassifier.ResolveGraceHours).
+        /// </para>
         /// </summary>
-        public int SessionGraceHours { get; set; } = 72;
+        public int SessionGraceHours { get; set; } = 0;
 
         // ===== PAYLOAD SETTINGS =====
 
@@ -246,6 +251,16 @@ namespace AutopilotMonitor.Shared.Models
         /// null = use default (360 = 6 hours). 0 = disabled (no lifetime limit).
         /// </summary>
         public int? AgentMaxLifetimeMinutes { get; set; }
+
+        /// <summary>
+        /// Absolute per-session age cap in hours enforced by the agent's emergency break
+        /// (Program.Guards.CheckSessionAgeEmergencyBreak → AgentConfiguration.AbsoluteMaxSessionHours).
+        /// null = agent default (48). Mirrored here so the backend can derive the session-grace floor from
+        /// the same value: the timeout grace is never shorter than this cap + buffer. NOTE: the agent still
+        /// reads its own AbsoluteMaxSessionHours today; wiring this override down to the agent config
+        /// response is a follow-up so the two stay in lockstep.
+        /// </summary>
+        public int? AbsoluteMaxSessionHours { get; set; }
 
         // ===== AGENT BEHAVIOR OVERRIDES =====
 
@@ -843,7 +858,7 @@ namespace AutopilotMonitor.Shared.Models
                 AllowInsecureAgentRequests = false,
                 DataRetentionDays = 90,
                 SessionTimeoutHours = 5,
-                SessionGraceHours = 72,
+                SessionGraceHours = 0, // auto-derive: AbsoluteMaxSessionHours + buffer (= 60h)
                 MaxNdjsonPayloadSizeMB = 5,
                 EnablePerformanceCollector = true,
                 PerformanceCollectorIntervalSeconds = 30,

--- a/src/Shared/AutopilotMonitor.Shared/Models/Config/TenantConfiguration.cs
+++ b/src/Shared/AutopilotMonitor.Shared/Models/Config/TenantConfiguration.cs
@@ -176,9 +176,12 @@ namespace AutopilotMonitor.Shared.Models
         public int DataRetentionDays { get; set; } = 90;
 
         /// <summary>
-        /// Session timeout in hours
-        /// Sessions in "InProgress" status longer than this will be marked as "Failed - Timed Out"
-        /// This prevents stalled sessions from running indefinitely and skewing statistics
+        /// Session inactivity timeout in hours. Once an "InProgress" session is idle past this, the
+        /// maintenance sweep reclassifies it out of "InProgress" (see
+        /// docs/design/enrollment-status-reclassification.md): if Device Setup already finished it
+        /// becomes AwaitingUser (non-terminal), otherwise it eventually settles as the terminal,
+        /// non-failure Incomplete state once <see cref="SessionGraceHours"/> elapses — it is NOT
+        /// counted as a failure. This prevents stalled sessions from running indefinitely and skewing statistics.
         /// Recommended: Use the same value as your ESP (Enrollment Status Page) timeout
         /// Default: 5 hours
         /// </summary>
@@ -191,7 +194,7 @@ namespace AutopilotMonitor.Shared.Models
         /// of Failed; only after this window elapses without a completion does it graduate to the terminal,
         /// non-failure Incomplete state.
         /// <para>
-        /// 0 (default) = auto-derive: <c>AbsoluteMaxSessionHours + 12h buffer</c> (= 60h with defaults). The
+        /// 0 (default) = auto-derive: <c>AbsoluteMaxSessionHours + buffer</c> (= 48h + 3h = 51h with defaults). The
         /// grace is always floored at the agent's absolute session-age cap plus buffer — until that cap fires
         /// the agent may still be legitimately enrolling, and because the cap is silent to the backend anything
         /// still quiet past cap+buffer is provably dead. A non-zero value acts as an override but can only
@@ -858,7 +861,7 @@ namespace AutopilotMonitor.Shared.Models
                 AllowInsecureAgentRequests = false,
                 DataRetentionDays = 90,
                 SessionTimeoutHours = 5,
-                SessionGraceHours = 0, // auto-derive: AbsoluteMaxSessionHours + buffer (= 60h)
+                SessionGraceHours = 0, // auto-derive: AbsoluteMaxSessionHours + buffer (= 48h + 3h = 51h)
                 MaxNdjsonPayloadSizeMB = 5,
                 EnablePerformanceCollector = true,
                 PerformanceCollectorIntervalSeconds = 30,

--- a/src/Shared/AutopilotMonitor.Shared/Models/Diagnostics/AgentErrorReport.cs
+++ b/src/Shared/AutopilotMonitor.Shared/Models/Diagnostics/AgentErrorReport.cs
@@ -28,6 +28,16 @@ namespace AutopilotMonitor.Shared.Models
         /// the hash provided by the backend. Possible tampering or stale blob storage.
         /// </summary>
         IntegrityCheckFailed = 3,
+
+        /// <summary>
+        /// The agent's absolute session-age emergency break fired
+        /// (Program.Guards.CheckSessionAgeEmergencyBreak → AbsoluteMaxSessionHours): the agent is
+        /// cleaning up and exiting. Best-effort report over the resilient emergency channel (may be
+        /// lost if the device is fully offline) so the backend can materialize an
+        /// <c>agent_emergency_break</c> timeline event and terminalize the session instead of waiting
+        /// out the silence grace. See docs/design/enrollment-status-reclassification.md.
+        /// </summary>
+        SessionAgeEmergencyBreak = 4,
     }
 
     /// <summary>

--- a/src/Shared/AutopilotMonitor.Shared/Models/FleetHealthModels.cs
+++ b/src/Shared/AutopilotMonitor.Shared/Models/FleetHealthModels.cs
@@ -34,6 +34,8 @@ namespace AutopilotMonitor.Shared.Models
         public int Succeeded { get; set; }
         public int Failed { get; set; }
         public int InProgress { get; set; }
+        /// <summary>Terminal, non-failure sessions (timeout reclassification). Surfaced as its own count; not a failure.</summary>
+        public int Incomplete { get; set; }
         /// <summary>Succeeded / total * 100 (one decimal). Note: over all sessions, not just terminal.</summary>
         public double SuccessRate { get; set; }
         /// <summary>Average duration in minutes over non-in-progress sessions that carry a duration.</summary>

--- a/src/Shared/AutopilotMonitor.Shared/Models/SessionApiModels.cs
+++ b/src/Shared/AutopilotMonitor.Shared/Models/SessionApiModels.cs
@@ -430,7 +430,17 @@ namespace AutopilotMonitor.Shared.Models
         Stalled,      // Agent reported no progress for >60 min, or backend sweep detected >2h silence. Non-terminal, can heal back to InProgress.
         Succeeded,
         Failed,
-        Unknown
+        Unknown,
+        // Appended 2026-07-08 (docs/design/enrollment-status-reclassification.md). New members
+        // MUST stay appended so existing persisted ordinals never shift.
+        AwaitingUser, // Device Setup (ESP DeviceSetup) fully succeeded but the user/Account-Setup
+                      // phase has not completed and the agent went silent within the grace window.
+                      // NON-TERMINAL: reconciles to Succeeded on a late completion, or graduates to
+                      // Incomplete once SessionGraceHours elapses. NOT a failure.
+        Incomplete    // Terminal, NON-FAILURE. The session never produced a terminal completion or
+                      // failure signal and the grace window expired (or it went silent before Device
+                      // Setup completed with no explicit failure). Excluded from the failure-rate
+                      // denominator; surfaced to operators as "Incomplete".
     }
 
     /// <summary>

--- a/src/Shared/AutopilotMonitor.Shared/Models/SessionApiModels.cs
+++ b/src/Shared/AutopilotMonitor.Shared/Models/SessionApiModels.cs
@@ -464,6 +464,13 @@ namespace AutopilotMonitor.Shared.Models
         public int FailedLastNDays { get; set; }
 
         /// <summary>
+        /// Terminal, non-failure sessions in the window (docs/design/enrollment-status-reclassification.md):
+        /// the sweep saw no completion or explicit failure. Reported as the third headline bucket and
+        /// deliberately excluded from <see cref="SuccessRatePct"/> (which is over Succeeded + Failed only).
+        /// </summary>
+        public int IncompleteLastNDays { get; set; }
+
+        /// <summary>
         /// Succeeded / (Succeeded + Failed) * 100, rounded. Zero when no terminal
         /// sessions are in the window (the card renders "0%" rather than NaN).
         /// </summary>

--- a/src/Web/autopilot-monitor-web/app/dashboard/components/SessionTable.tsx
+++ b/src/Web/autopilot-monitor-web/app/dashboard/components/SessionTable.tsx
@@ -587,6 +587,9 @@ export function SessionTable({
                 InProgress: "text-blue-600",
                 Pending: "text-amber-600",
                 Stalled: "text-orange-600",
+                // Reclassification states — mirror SessionStatusBadge (sky = awaiting user, slate = incomplete)
+                AwaitingUser: "text-sky-600",
+                Incomplete: "text-slate-600",
               };
               return (
                 <button
@@ -667,13 +670,17 @@ export function SessionTable({
 
       {/* Status Filter Badges */}
       <div className="mb-4 flex items-center gap-2 flex-wrap">
-        {(["Succeeded", "InProgress", "Pending", "Stalled", "Failed"] as const).map((status) => {
+        {(["Succeeded", "InProgress", "Pending", "Stalled", "AwaitingUser", "Failed", "Incomplete"] as const).map((status) => {
           const config: Record<string, { bg: string; bgActive: string; text: string; label: string }> = {
             Succeeded: { bg: "bg-green-50 text-green-700 border-green-200 hover:bg-green-100", bgActive: "bg-green-600 text-white border-green-600", text: "text-green-600", label: "Succeeded" },
             InProgress: { bg: "bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-100", bgActive: "bg-blue-600 text-white border-blue-600", text: "text-blue-600", label: "In Progress" },
             Pending: { bg: "bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-100", bgActive: "bg-amber-500 text-white border-amber-500", text: "text-amber-600", label: "Pending" },
             Stalled: { bg: "bg-orange-50 text-orange-700 border-orange-200 hover:bg-orange-100", bgActive: "bg-orange-600 text-white border-orange-600", text: "text-orange-600", label: "Stalled" },
+            // Non-terminal reclassification state (Device Setup done, waiting on user) — sky, mirrors SessionStatusBadge.
+            AwaitingUser: { bg: "bg-sky-50 text-sky-700 border-sky-200 hover:bg-sky-100", bgActive: "bg-sky-600 text-white border-sky-600", text: "text-sky-600", label: "Awaiting User" },
             Failed: { bg: "bg-red-50 text-red-700 border-red-200 hover:bg-red-100", bgActive: "bg-red-600 text-white border-red-600", text: "text-red-600", label: "Failed" },
+            // Terminal but NOT a failure (went silent, no completion) — neutral slate, clearly not red.
+            Incomplete: { bg: "bg-slate-50 text-slate-700 border-slate-200 hover:bg-slate-100", bgActive: "bg-slate-600 text-white border-slate-600", text: "text-slate-600", label: "Incomplete" },
           };
           const c = config[status];
           const count = sessions.filter(s => s.status === status).length;

--- a/src/Web/autopilot-monitor-web/app/fleet-health/components/FleetStatCard.tsx
+++ b/src/Web/autopilot-monitor-web/app/fleet-health/components/FleetStatCard.tsx
@@ -9,13 +9,14 @@ export default function FleetStatCard({
   title: string;
   value: string;
   subtitle: string;
-  color: "green" | "blue" | "red" | "yellow";
+  color: "green" | "blue" | "red" | "yellow" | "slate";
 }) {
   const colorClasses = {
     green: "border-green-500 bg-green-50",
     blue: "border-blue-500 bg-blue-50",
     red: "border-red-500 bg-red-50",
     yellow: "border-yellow-500 bg-yellow-50",
+    slate: "border-slate-400 bg-slate-50",
   };
 
   const valueColors = {
@@ -23,6 +24,7 @@ export default function FleetStatCard({
     blue: "text-blue-700",
     red: "text-red-700",
     yellow: "text-yellow-700",
+    slate: "text-slate-600",
   };
 
   return (

--- a/src/Web/autopilot-monitor-web/app/fleet-health/hooks/useFleetHealth.ts
+++ b/src/Web/autopilot-monitor-web/app/fleet-health/hooks/useFleetHealth.ts
@@ -14,6 +14,8 @@ export interface FleetHealthStats {
   succeeded: number;
   failed: number;
   inProgress: number;
+  /** Terminal, non-failure (timeout reclassification). Surfaced separately; not counted as a failure. */
+  incomplete: number;
   successRate: number;
   avgDurationMinutes: number;
 }

--- a/src/Web/autopilot-monitor-web/app/fleet-health/page.tsx
+++ b/src/Web/autopilot-monitor-web/app/fleet-health/page.tsx
@@ -124,6 +124,7 @@ export default function FleetHealthPage() {
     succeeded: s?.succeeded ?? 0,
     failed: s?.failed ?? 0,
     inProgress: s?.inProgress ?? 0,
+    incomplete: s?.incomplete ?? 0,
     successRate: s?.successRate ?? 0,
     avgDuration: s?.avgDurationMinutes ?? 0,
   };
@@ -223,7 +224,7 @@ export default function FleetHealthPage() {
 
         <main className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
           {/* Top Stats */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5 mb-8">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-5 mb-8">
             <FleetStatCard
               title="Success Rate"
               value={`${stats.successRate.toFixed(1)}%`}
@@ -247,6 +248,12 @@ export default function FleetHealthPage() {
               value={stats.failed.toString()}
               subtitle="Needs attention"
               color="red"
+            />
+            <FleetStatCard
+              title="Incomplete"
+              value={stats.incomplete.toString()}
+              subtitle="No completion signal — not a failure"
+              color="slate"
             />
             <FleetStatCard
               title="Active Now"

--- a/src/Web/autopilot-monitor-web/app/sessions/[sessionId]/components/SessionInfoCard.tsx
+++ b/src/Web/autopilot-monitor-web/app/sessions/[sessionId]/components/SessionInfoCard.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Session } from "@/types";
+import { SessionStatusBadge } from "@/components/SessionStatusBadge";
 import FailureSnapshotBlock from "./FailureSnapshotBlock";
 
 interface SessionInfoCardProps {
@@ -160,52 +161,30 @@ function InfoItem({ label, value, copyText, tooltip }: { label: string; value: R
 }
 
 function StatusBadge({ status, failureReason, failureSource, adminMarkedAction }: { status: string; failureReason?: string; failureSource?: string; adminMarkedAction?: string }) {
-  const statusConfig = {
-    InProgress: { color: "bg-blue-100 text-blue-800", text: "In Progress" },
-    Pending: { color: "bg-amber-100 text-amber-800", text: "Pending" },
-    Stalled: { color: "bg-orange-100 text-orange-800", text: "Stalled" },
-    Succeeded: { color: "bg-green-100 text-green-800", text: "Succeeded" },
-    Failed: { color: "bg-red-100 text-red-800", text: "Failed" },
-    Unknown: { color: "bg-gray-100 text-gray-800", text: "Unknown" },
-  };
+  // Delegate the status pill (+ timeout affordance + "manual" badge) to the shared, canonical
+  // SessionStatusBadge so this page picks up every status — incl. the AwaitingUser/Incomplete
+  // reclassification states — from one source instead of a divergent local map.
+  const badge = (
+    <SessionStatusBadge status={status} failureReason={failureReason} adminMarkedAction={adminMarkedAction} />
+  );
 
-  const config = statusConfig[status as keyof typeof statusConfig] || statusConfig.Unknown;
-
-  const isTimeout = status === "Failed" && failureReason && failureReason.toLowerCase().includes("timed out");
+  // Session-detail-only affordance: link a rule-attributed failure back to its analyze rule.
   const ruleId = status === "Failed" && failureSource && failureSource.startsWith("rule:")
     ? failureSource.substring("rule:".length)
     : null;
 
+  if (!ruleId) return badge;
+
   return (
     <span className="inline-flex items-center gap-1.5">
-      <span
-        className={`px-2 inline-flex items-center gap-1 text-xs leading-5 font-semibold rounded-full ${config.color}`}
-        title={failureReason || undefined}
+      {badge}
+      <a
+        href={`/analyze-rules?highlight=${encodeURIComponent(ruleId)}`}
+        className="px-1.5 py-0.5 text-[10px] leading-4 font-semibold rounded border border-red-300 bg-red-50 text-red-700 hover:bg-red-100 transition-colors"
+        title={`Failed by analyze rule ${ruleId}${failureReason ? ` — ${failureReason}` : ""}`}
       >
-        {config.text}
-        {isTimeout && (
-          <span title={failureReason} className="inline-flex items-center">
-            ⏱️
-          </span>
-        )}
-      </span>
-      {ruleId && (
-        <a
-          href={`/analyze-rules?highlight=${encodeURIComponent(ruleId)}`}
-          className="px-1.5 py-0.5 text-[10px] leading-4 font-semibold rounded border border-red-300 bg-red-50 text-red-700 hover:bg-red-100 transition-colors"
-          title={`Failed by analyze rule ${ruleId}${failureReason ? ` — ${failureReason}` : ""}`}
-        >
-          via rule {ruleId}
-        </a>
-      )}
-      {adminMarkedAction && (
-        <span
-          className="px-1.5 py-0.5 text-[10px] leading-4 font-semibold rounded border border-gray-300 bg-gray-50 text-gray-600"
-          title={`Manually marked as ${adminMarkedAction} by administrator`}
-        >
-          manual
-        </span>
-      )}
+        via rule {ruleId}
+      </a>
     </span>
   );
 }

--- a/src/Web/autopilot-monitor-web/app/sessions/[sessionId]/hooks/useSessionEvents.ts
+++ b/src/Web/autopilot-monitor-web/app/sessions/[sessionId]/hooks/useSessionEvents.ts
@@ -210,7 +210,7 @@ export function useSessionEvents({
       }
 
       const currentStatus = sessionRef.current?.status;
-      if (foundTerminalEvent && currentStatus && currentStatus !== "Succeeded" && currentStatus !== "Failed") {
+      if (foundTerminalEvent && currentStatus && !isTerminalStatus(currentStatus)) {
         console.info(
           `[SessionDetail] Terminal event detected but session status is '${currentStatus}' — refetching session details`
         );

--- a/src/Web/autopilot-monitor-web/app/settings/components/DataManagementSection.tsx
+++ b/src/Web/autopilot-monitor-web/app/settings/components/DataManagementSection.tsx
@@ -87,8 +87,10 @@ export default function DataManagementSection({
           <label className="block">
             <span className="text-gray-700 font-medium">Session Timeout (Hours)</span>
             <p className="text-sm text-gray-500 mb-2">
-              Sessions in "InProgress" status longer than this will be marked as "Failed - Timed Out".
-              This prevents stalled sessions from running indefinitely and skewing statistics.
+              Sessions inactive past this timeout are reclassified out of "In Progress": if Device Setup
+              already finished they become "Awaiting User", otherwise they eventually settle as "Incomplete"
+              (a non-completion, not counted as a failure). This keeps stalled sessions from running
+              indefinitely and skewing statistics.
               <br />
               <strong>Tip:</strong> Use the same value as your ESP (Enrollment Status Page) timeout for consistency.
             </p>

--- a/src/Web/autopilot-monitor-web/components/SessionStatusBadge.tsx
+++ b/src/Web/autopilot-monitor-web/components/SessionStatusBadge.tsx
@@ -10,8 +10,12 @@ const STATUS_CONFIG: Record<string, { color: string; text: string }> = {
   InProgress: { color: "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300", text: "In Progress" },
   Pending: { color: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300", text: "Pending" },
   Stalled: { color: "bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300", text: "Stalled" },
+  // Non-terminal: Device Setup done, waiting on the user / Account-Setup phase. Blue-ish "still going".
+  AwaitingUser: { color: "bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-300", text: "Awaiting User" },
   Succeeded: { color: "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300", text: "Succeeded" },
   Failed: { color: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300", text: "Failed" },
+  // Terminal but NOT a failure — no completion or explicit failure signal. Neutral slate, clearly not red.
+  Incomplete: { color: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300", text: "Incomplete" },
   Unknown: { color: "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300", text: "Unknown" },
 };
 
@@ -26,7 +30,11 @@ export function SessionStatusBadge({
   adminMarkedAction?: string | null;
 }) {
   const config = STATUS_CONFIG[status] || STATUS_CONFIG.Unknown;
-  const isTimeout = status === "Failed" && !!failureReason?.toLowerCase().includes("timed out");
+  // The ⏱️ affordance marks the silence/timeout family: a "timed out" Failed, or any Incomplete
+  // (which is, by definition, a session that went silent without a completion).
+  const isTimeout =
+    (status === "Failed" && !!failureReason?.toLowerCase().includes("timed out")) ||
+    status === "Incomplete";
 
   const pill = (
     <span

--- a/src/Web/autopilot-monitor-web/utils/sessionStatus.ts
+++ b/src/Web/autopilot-monitor-web/utils/sessionStatus.ts
@@ -1,8 +1,12 @@
 // Session status helpers. Mirror of the backend SessionStatus enum
 // (src/Shared/AutopilotMonitor.Shared/Models/SessionApiModels.cs).
-// Non-terminal: InProgress, Pending, Stalled, Unknown.
-// Terminal: Succeeded, Failed.
+// Non-terminal: InProgress, Pending, Stalled, AwaitingUser, Unknown.
+// Terminal: Succeeded, Failed, Incomplete.
+//
+// AwaitingUser (Device Setup done, user/Account-Setup phase pending) and Incomplete
+// (terminal, non-failure — no completion or explicit failure was observed) come from the
+// timeout reclassification, see docs/design/enrollment-status-reclassification.md.
 
 export function isTerminalStatus(status: string | null | undefined): boolean {
-  return status === "Succeeded" || status === "Failed";
+  return status === "Succeeded" || status === "Failed" || status === "Incomplete";
 }


### PR DESCRIPTION
## What & why

Enrollment sessions that ran into the inactivity timeout were classified as **Failed**, inflating the failure rate. A stalled/abandoned enrollment (user walked away, left the ESP open) is not the same as a real failure. This branch introduces honest, non-failure timeout states and stops counting them as failures.

## New session states
- **`AwaitingUser`** (non-terminal) — Device Setup finished, waiting on the user / Account-Setup phase.
- **`Incomplete`** (terminal, **not** a failure) — session went silent with no completion or explicit failure signal.

Both are derived by a pure classifier (`EnrollmentTimeoutClassifier`) that reads the ESP subcategory rollup the agent already emits; the maintenance sweep applies them, a late completion still reconciles `Incomplete`/`Failed` back up to `Succeeded`, and the fleet-health failure rate now excludes `Incomplete`.

## Surfaces
- **Backend:** timeout classifier + `AwaitingUser`/`Incomplete` states, sweep reclassification (PR1–PR2), late-completion reconcile (PR3), `Incomplete` as a third fleet-health state + honest failure rate (PR4), `agent_emergency_break` timeline event materialization.
- **Agent (net48):** best-effort emergency-break report.
- **Web:** Fleet Health, dashboard table (badge + search + status filters), and session detail surface the new states.

## Review hardening (4 review rounds, all addressed)
- ETag force-fallback in `UpdateSessionStatusAsync` mirrors the normal path (terminal guard, admin-marked guard, reason/snapshot for `Incomplete`/`AwaitingUser`).
- `StoreSessionAsync` CAS loop preserves a terminal that lands in the fresh-read window (no re-registration regression).
- `SessionGraceHours` + `AbsoluteMaxSessionHours` roundtrip through the tenant-config Store/Map pair.
- `ResolveGraceHours` clamps the assumed agent cap to ≥ the real 48h runtime default until the agent honors the override — a low override can never terminalize a live session early.
- `Incomplete` reconciles counters like `Failed`, plus a re-reconcile after the synthetic `session_timeout` event (also fixes a pre-existing Failed off-by-one).
- Web: shared `SessionStatusBadge` reused on session detail; `isTerminalStatus()` used consistently; stale copy/comments corrected.

## Verification
- Full backend test suite green (2712 tests, 0 failures); web `tsc --noEmit` clean.
- New tests: grace-clamp case, grace/abs-cap config roundtrip + legacy-row defaults, plus the branch's classifier/status-transition/bucket suites.

## Follow-ups (not in this PR)
- Wire `TenantConfiguration.AbsoluteMaxSessionHours` down into `AgentConfigResponse` so the agent honors the override too (then the backend clamp can be relaxed).
- PR6 historical backfill (deferred until forward-only looks good).
- Customer-facing GitBook (`autopilotmonitor-docs`) update for the new states — tracked as a post-deploy item in `tasks/todo.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)